### PR TITLE
#43 - Add interfaces for common models of Shopware 6

### DIFF
--- a/packages/shopware-6-client/src/interfaces/models/common/Collection.ts
+++ b/packages/shopware-6-client/src/interfaces/models/common/Collection.ts
@@ -1,3 +1,0 @@
-export interface Collection {
-  elements: [];
-}

--- a/packages/shopware-6-client/src/interfaces/models/common/Collection.ts
+++ b/packages/shopware-6-client/src/interfaces/models/common/Collection.ts
@@ -1,0 +1,3 @@
+export interface Collection {
+  elements: [];
+}

--- a/packages/shopware-6-client/src/interfaces/models/common/CustomField.ts
+++ b/packages/shopware-6-client/src/interfaces/models/common/CustomField.ts
@@ -1,0 +1,1 @@
+export interface CustomField {}

--- a/packages/shopware-6-client/src/interfaces/models/common/Entity.ts
+++ b/packages/shopware-6-client/src/interfaces/models/common/Entity.ts
@@ -1,3 +1,8 @@
+/**
+ * Parent interface of all the interfaces for Shopware model entities.
+ *
+ * It provides the following fields: _uniqueIdentifier:string, versionId:string, translated[], createdAt:Date|null, updatedat:Date|null.
+ */
 export interface Entity {
   _uniqueIdentifier: string;
   versionId: string;

--- a/packages/shopware-6-client/src/interfaces/models/common/Entity.ts
+++ b/packages/shopware-6-client/src/interfaces/models/common/Entity.ts
@@ -1,0 +1,7 @@
+export interface Entity {
+  _uniqueIdentifier: string;
+  versionId: string;
+  translated: [];
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}


### PR DESCRIPTION
**Changes:**
* Add interfaces for `common` group.
* Right now it contains following interfaces: `Entity`, `Collection`, `CustomField`.

**To do:**
* `CustomField` interface to be filled in #61 

**Issue:**
#43 