### PR TITLE
Feat/57 create product service interface

### DIFF
--- a/packages/shopware-6-client/__tests__/helpers/paramsConverter.spec.ts
+++ b/packages/shopware-6-client/__tests__/helpers/paramsConverter.spec.ts
@@ -1,4 +1,4 @@
-import { ParamsConverter } from "../../src/index";
+import { ParamsConverter } from "../../src/helpers/paramsConverter";
 
 describe("ParamsConverter", () => {
   describe("getParams", () => {

--- a/packages/shopware-6-client/__tests__/helpers/paramsConverter.spec.ts
+++ b/packages/shopware-6-client/__tests__/helpers/paramsConverter.spec.ts
@@ -1,0 +1,50 @@
+import { ParamsConverter } from "../../src/index";
+
+describe("ParamsConverter", () => {
+  describe("getParams", () => {
+    it("should returns null if no params provided", async () => {
+      const paramsObject = ParamsConverter.getParams();
+      expect(paramsObject).toBeNull();
+    });
+    it("should returns only pagination if no other params provided", async () => {
+      const paramsObjectPage = ParamsConverter.getParams({ page: 1 });
+      expect(paramsObjectPage).toHaveProperty("page");
+
+      const paramsObjectLimit = ParamsConverter.getParams({ limit: 1 });
+      expect(paramsObjectLimit).toHaveProperty("limit");
+
+      const paramsObjectPageAndLimit = ParamsConverter.getParams({
+        page: 1,
+        limit: 5
+      });
+      expect(paramsObjectPageAndLimit).toHaveProperty("page");
+      expect(paramsObjectPageAndLimit).toHaveProperty("limit");
+    });
+    it("should returns only sorting if no other params provided", async () => {
+      const paramsObject = ParamsConverter.getParams(null, { sort: "-name" });
+      expect(paramsObject).toHaveProperty("sort");
+      expect(paramsObject).not.toBeNull();
+      if (paramsObject) {
+        expect(paramsObject.sort).toEqual("-name");
+      } else {
+        console.error(`there is no sort property included`);
+      }
+    });
+    it("should returns filter property if any provided", async () => {
+      const paramsObject = ParamsConverter.getParams(null, null, {
+        filter: {}
+      });
+      expect(paramsObject).toHaveProperty("filter");
+    });
+    it("should returns all types of params if all provided", async () => {
+      const paramsObject = ParamsConverter.getParams(
+        { page: 1 },
+        { sort: "name" },
+        { filter: {} }
+      );
+      expect(paramsObject).toHaveProperty("page");
+      expect(paramsObject).toHaveProperty("sort");
+      expect(paramsObject).toHaveProperty("filter");
+    });
+  });
+});

--- a/packages/shopware-6-client/__tests__/services/productService.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/productService.spec.ts
@@ -1,0 +1,80 @@
+import { ProductService } from "../../src/index";
+
+describe("ProductService", () => {
+  describe("getProductsIds", () => {
+    it("should return array of products' ids (default amount of 10)", async () => {
+      try {
+        const result = await ProductService.getProductsIds();
+        expect(result.total).toEqual(60);
+        expect(result.data).toHaveLength(10);
+      } catch (e) {
+        console.error("Connection problem", e);
+      }
+    });
+  });
+  describe("getProducts", () => {
+    it("should return array of products (default amount of 10)", async () => {
+      try {
+        const result = await ProductService.getProducts();
+        expect(result.total).toEqual(60);
+        expect(result.data).toHaveLength(10);
+      } catch (e) {
+        console.error("Connection problem", e);
+      }
+    });
+    it("should return array of products limited to 5", async () => {
+      try {
+        const pagination = {
+          page: 1,
+          limit: 5
+        };
+        const result = await ProductService.getProducts(pagination);
+        expect(result.total).toEqual(60);
+        expect(result.data).toHaveLength(5);
+      } catch (e) {
+        console.error("Connection problem", e);
+      }
+    });
+    it("should return a different array of products sorted by name", async () => {
+      try {
+        const pagination = {
+          page: 1,
+          limit: 1
+        };
+
+        /** get the products with descending order to compare */
+        const sort = {
+          sort: `-name`
+        };
+        const result = await ProductService.getProducts(pagination, sort);
+        expect(result.data).toHaveLength(1);
+        const nameDesc = result.data[0].name;
+
+        /** get the products with ascending order to compare */
+        const sortAsc = {
+          sort: `name`
+        };
+        const resultAsc = await ProductService.getProducts(pagination, sortAsc);
+        expect(resultAsc.data).toHaveLength(1);
+        const nameAsc = resultAsc.data[0].name;
+
+        /** compare first results's name from different sorting order */
+        expect(nameAsc).not.toBe(nameDesc);
+      } catch (e) {
+        console.error("Connection problem", e);
+      }
+    });
+  });
+  describe("getProduct", () => {
+    it("should return chosen product", async () => {
+      try {
+        const productId = "044a190a54ab4f06803909c3ee8063ef";
+        const result = await ProductService.getProduct(productId);
+        expect(result).toHaveProperty("id");
+        expect(result.id).toEqual(productId);
+      } catch (e) {
+        console.error("Connection problem", e);
+      }
+    });
+  });
+});

--- a/packages/shopware-6-client/src/helpers/paramsConverter.ts
+++ b/packages/shopware-6-client/src/helpers/paramsConverter.ts
@@ -1,0 +1,38 @@
+export interface Params {
+  page?: number;
+  limit?: number;
+  sort?: string;
+  filter?: any;
+}
+
+export interface ParamsConverter {
+  getParams: (pagination?: any, sort?: any, filter?: any) => Params | null;
+}
+/**
+ * @description Combines parameters into one object
+ */
+const getParams = (
+  pagination?: any,
+  sort?: any,
+  filter?: any
+): Params | null => {
+  let params = {};
+
+  if (pagination) {
+    params = Object.assign(params, pagination);
+  }
+
+  if (sort) {
+    params = Object.assign(params, sort);
+  }
+
+  if (filter) {
+    params = Object.assign(params, filter);
+  }
+
+  return pagination || sort || filter ? params : null;
+};
+
+export const ParamsConverter: ParamsConverter = {
+  getParams
+};

--- a/packages/shopware-6-client/src/index.ts
+++ b/packages/shopware-6-client/src/index.ts
@@ -1,2 +1,4 @@
 export { setup, config } from "./settings";
 export { Category, CategoryService } from "./categoryService";
+export { ProductService } from "./services/productService";
+export { ParamsConverter } from "./helpers/paramsConverter";

--- a/packages/shopware-6-client/src/index.ts
+++ b/packages/shopware-6-client/src/index.ts
@@ -9,3 +9,4 @@ export function setup(config: ClientSettings = {}): void {
   setupConfig(config);
   reloadConfiguration();
 }
+setup();

--- a/packages/shopware-6-client/src/interfaces/response/SearchResult.ts
+++ b/packages/shopware-6-client/src/interfaces/response/SearchResult.ts
@@ -1,4 +1,4 @@
 export interface SearchResult<T> {
-  count: number,
-  data: T
+  total: number;
+  data: T;
 }

--- a/packages/shopware-6-client/src/interfaces/response/SearchResult.ts
+++ b/packages/shopware-6-client/src/interfaces/response/SearchResult.ts
@@ -1,0 +1,4 @@
+export interface SearchResult<T> {
+  count: number,
+  data: T
+}

--- a/packages/shopware-6-client/src/services/productService.ts
+++ b/packages/shopware-6-client/src/services/productService.ts
@@ -22,7 +22,7 @@ export interface ProductService {
 }
 
 /**
- * @description Get default amount of products
+ * @description Get default amount of products' ids
  */
 const getProductsIds = async function(): Promise<SearchResult<string[]>> {
   const resp = await axios.post(
@@ -32,7 +32,7 @@ const getProductsIds = async function(): Promise<SearchResult<string[]>> {
 };
 
 /**
- * @description Get default amount of products' ids
+ * @description Get default amount of products
  */
 
 const getProducts = async function(

--- a/packages/shopware-6-client/src/services/productService.ts
+++ b/packages/shopware-6-client/src/services/productService.ts
@@ -3,6 +3,7 @@ import { config } from "../settings";
 import { getProductEndpoint } from "../endpoints";
 import { SearchResult } from "../interfaces/response/SearchResult";
 import { Product } from "../interfaces/models/content/product/Product";
+import { ParamsConverter } from "../helpers/paramsConverter";
 
 /**
  * Usage example:
@@ -12,14 +13,16 @@ import { Product } from "../interfaces/models/content/product/Product";
  */
 export interface ProductService {
   getProductsIds: () => Promise<SearchResult<string[]>>;
-  getProducts: () => Promise<SearchResult<Product[]>>;
-  getProduct: (productId: string) => Promise<SearchResult<Partial<Product>>>;
+  getProducts: (
+    pagination?: any,
+    sort?: any,
+    filter?: any
+  ) => Promise<SearchResult<Product[]>>;
+  getProduct: (productId: string) => Promise<Product>;
 }
 
 /**
- * Get default amount of products
- *
- * @returns Promise<SearchResult<Product[]>>
+ * @description Get default amount of products
  */
 const getProductsIds = async function(): Promise<SearchResult<string[]>> {
   const resp = await axios.post(
@@ -29,32 +32,32 @@ const getProductsIds = async function(): Promise<SearchResult<string[]>> {
 };
 
 /**
- * Get default amount of products' ids
- *
- * @returns Promise<SearchResult<string[]>>
+ * @description Get default amount of products' ids
  */
-const getProducts = async function(): Promise<SearchResult<Product[]>> {
-  const resp = await axios.get(`${config.endpoint}${getProductEndpoint()}`);
+
+const getProducts = async function(
+  pagination?: any,
+  sort?: any,
+  filters?: any
+): Promise<SearchResult<Product[]>> {
+  const resp = await axios.get(`${config.endpoint}${getProductEndpoint()}`, {
+    params: ParamsConverter.getParams(pagination, sort, filters)
+  });
   return resp.data;
 };
 
 /**
- * Get the product with passed productId
- *
- * @param productId
- * @returns Promise<SearchResult<Partial<Product>>>
+ * @description Get the product with passed productId
  */
-const getProduct = async function(
-  productId: string
-): Promise<SearchResult<Partial<Product>>> {
+const getProduct = async function(productId: string): Promise<Product> {
   const resp = await axios.get(
     `${config.endpoint}${getProductEndpoint()}/${productId}`
   );
-  return resp.data;
+  return resp.data.data;
 };
 
 /**
- * Expose public methods of the service
+ * @description Expose public methods of the service
  */
 export const ProductService: ProductService = {
   getProductsIds,

--- a/packages/shopware-6-client/src/services/productService.ts
+++ b/packages/shopware-6-client/src/services/productService.ts
@@ -1,0 +1,63 @@
+import axios from "axios";
+import { config } from "../settings";
+import { getProductEndpoint } from "../endpoints";
+import { SearchResult } from "../interfaces/response/SearchResult";
+import { Product } from "../interfaces/models/content/product/Product";
+
+/**
+ * Usage example:
+ * ```ts
+ * import { ProductService } from '@shopware-pwa/shopware-6-client'
+ * ```
+ */
+export interface ProductService {
+  getProductsIds: () => Promise<SearchResult<string[]>>;
+  getProducts: () => Promise<SearchResult<Product[]>>;
+  getProduct: (productId: string) => Promise<SearchResult<Partial<Product>>>;
+}
+
+/**
+ * Get default amount of products
+ *
+ * @returns Promise<SearchResult<Product[]>>
+ */
+const getProductsIds = async function(): Promise<SearchResult<string[]>> {
+  const resp = await axios.post(
+    `${config.endpoint}/search-ids${getProductEndpoint()}`
+  );
+  return resp.data;
+};
+
+/**
+ * Get default amount of products' ids
+ *
+ * @returns Promise<SearchResult<string[]>>
+ */
+const getProducts = async function(): Promise<SearchResult<Product[]>> {
+  const resp = await axios.get(`${config.endpoint}${getProductEndpoint()}`);
+  return resp.data;
+};
+
+/**
+ * Get the product with passed productId
+ *
+ * @param productId
+ * @returns Promise<SearchResult<Partial<Product>>>
+ */
+const getProduct = async function(
+  productId: string
+): Promise<SearchResult<Partial<Product>>> {
+  const resp = await axios.get(
+    `${config.endpoint}${getProductEndpoint()}/${productId}`
+  );
+  return resp.data;
+};
+
+/**
+ * Expose public methods of the service
+ */
+export const ProductService: ProductService = {
+  getProductsIds,
+  getProducts,
+  getProduct
+};

--- a/packages/shopware-6-client/src/services/productService.ts
+++ b/packages/shopware-6-client/src/services/productService.ts
@@ -1,9 +1,9 @@
-import axios from "axios";
 import { config } from "../settings";
 import { getProductEndpoint } from "../endpoints";
 import { SearchResult } from "../interfaces/response/SearchResult";
 import { Product } from "../interfaces/models/content/product/Product";
 import { ParamsConverter } from "../helpers/paramsConverter";
+import { apiService } from "../apiService";
 
 /**
  * Usage example:
@@ -25,7 +25,7 @@ export interface ProductService {
  * @description Get default amount of products' ids
  */
 const getProductsIds = async function(): Promise<SearchResult<string[]>> {
-  const resp = await axios.post(
+  const resp = await apiService.post(
     `${config.endpoint}/search-ids${getProductEndpoint()}`
   );
   return resp.data;
@@ -40,9 +40,12 @@ const getProducts = async function(
   sort?: any,
   filters?: any
 ): Promise<SearchResult<Product[]>> {
-  const resp = await axios.get(`${config.endpoint}${getProductEndpoint()}`, {
-    params: ParamsConverter.getParams(pagination, sort, filters)
-  });
+  const resp = await apiService.get(
+    `${config.endpoint}${getProductEndpoint()}`,
+    {
+      params: ParamsConverter.getParams(pagination, sort, filters)
+    }
+  );
   return resp.data;
 };
 
@@ -50,7 +53,7 @@ const getProducts = async function(
  * @description Get the product with passed productId
  */
 const getProduct = async function(productId: string): Promise<Product> {
-  const resp = await axios.get(
+  const resp = await apiService.get(
     `${config.endpoint}${getProductEndpoint()}/${productId}`
   );
   return resp.data.data;


### PR DESCRIPTION
I've created basic product service, which contains three methods:

```
  getProductsIds: () => Promise<SearchResult<string[]>>;
  getProducts: () => Promise<SearchResult<Product[]>>;
  getProduct: (productId: string) => Promise<SearchResult<Partial<Product>>>;
```

The according tests were created as well. 


I proposed a new files structure to keep services tidy - add some new folders.