### PR TITLE
Feature/client use on category page

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "scripts": {
     "dev": "node scripts/dev.js",
+    "dev:client": "yarn dev shopware-6-client -format=esm",
     "build": "node scripts/build.js",
     "postinstall": "yarn link-packages",
     "lint": "prettier --write --parser typescript 'packages/**/*.ts'",

--- a/packages/shopware-6-client/__tests__/helpers/convertSearchCriteria.spec.ts
+++ b/packages/shopware-6-client/__tests__/helpers/convertSearchCriteria.spec.ts
@@ -189,4 +189,45 @@ describe("SearchConverter - convertSearchCriteria", () => {
       });
     });
   });
+  describe("configuration", () => {
+    describe("associations", () => {
+      it("should return association", () => {
+        const result = convertSearchCriteria({
+          configuration: {
+            associations: [
+              {
+                name: "media"
+              }
+            ]
+          }
+        });
+        expect(result).toEqual({ associations: { media: {} } });
+      });
+
+      it("should not add associations on empty array", () => {
+        const result = convertSearchCriteria({
+          configuration: {
+            associations: []
+          }
+        });
+        expect(result).toEqual({});
+      });
+
+      it("should return multiple associations", () => {
+        const result = convertSearchCriteria({
+          configuration: {
+            associations: [
+              {
+                name: "media"
+              },
+              {
+                name: "stock"
+              }
+            ]
+          }
+        });
+        expect(result).toEqual({ associations: { media: {}, stock: {} } });
+      });
+    });
+  });
 });

--- a/packages/shopware-6-client/__tests__/helpers/convertSearchCriteria.spec.ts
+++ b/packages/shopware-6-client/__tests__/helpers/convertSearchCriteria.spec.ts
@@ -6,18 +6,22 @@ import {
   MultiFilter
 } from "../../src/interfaces/search/SearchFilter";
 import { PaginationLimit } from "../../src/interfaces/search/Pagination";
+import { config, setup, update } from "@shopware-pwa/shopware-6-client";
 
 describe("SearchConverter - convertSearchCriteria", () => {
+  beforeEach(() => {
+    setup();
+  });
   it("should returns empty object if no params provided", () => {
     const result = convertSearchCriteria();
     expect(result).toEqual({});
   });
   describe("pagination", () => {
-    it("should have page number", () => {
+    it("should have page number with default limit if not provided", () => {
       const result = convertSearchCriteria({
         pagination: { page: PaginationLimit.ONE }
       });
-      expect(result).toEqual({ page: 1 });
+      expect(result).toEqual({ page: 1, limit: config.defaultPaginationLimit });
     });
     it("should have page number", () => {
       const result = convertSearchCriteria({ pagination: { limit: 5 } });
@@ -40,6 +44,13 @@ describe("SearchConverter - convertSearchCriteria", () => {
       });
       expect(result).toEqual({ page: 3, limit: 5 });
     });
+    it("should change default pagination limit", () => {
+      update({ defaultPaginationLimit: 50 });
+      const result = convertSearchCriteria({
+        pagination: { page: PaginationLimit.ONE }
+      });
+      expect(result).toEqual({ page: 1, limit: 50 });
+    });
   });
   describe("sorting", () => {
     it("should have pagination and sort params", () => {
@@ -50,7 +61,11 @@ describe("SearchConverter - convertSearchCriteria", () => {
         },
         filters: []
       });
-      expect(paramsObject).toEqual({ page: 1, sort: "name" });
+      expect(paramsObject).toEqual({
+        page: 1,
+        limit: config.defaultPaginationLimit,
+        sort: "name"
+      });
     });
     it("should add prefix when desc sort", () => {
       const result = convertSearchCriteria({

--- a/packages/shopware-6-client/__tests__/services/ProductService/getProducts.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ProductService/getProducts.spec.ts
@@ -11,17 +11,17 @@ describe("ProductService - getProducts", () => {
     jest.resetAllMocks();
   });
   it("should return array of products (default amount of 10)", async () => {
-    mockedAxios.get.mockResolvedValueOnce({
+    mockedAxios.post.mockResolvedValueOnce({
       data: { total: 3, data: [1, 2, 3] }
     });
 
     const result = await getProducts();
     expect(result.total).toEqual(3);
     expect(result.data).toHaveLength(result.total);
-    expect(mockedAxios.get).toBeCalledTimes(1);
+    expect(mockedAxios.post).toBeCalledTimes(1);
   });
   it("should invoke api with limit", async () => {
-    mockedAxios.get.mockResolvedValueOnce({
+    mockedAxios.post.mockResolvedValueOnce({
       data: { total: 3, data: [1, 2, 3] }
     });
     const pagination = {
@@ -29,13 +29,11 @@ describe("ProductService - getProducts", () => {
       limit: 5
     };
     await getProducts({ pagination });
-    expect(mockedAxios.get).toBeCalledTimes(1);
-    expect(mockedAxios.get).toBeCalledWith("/product", {
-      params: { limit: 5, page: 1 }
-    });
+    expect(mockedAxios.post).toBeCalledTimes(1);
+    expect(mockedAxios.post).toBeCalledWith("/product", { limit: 5, page: 1 });
   });
   it("should invoke api with limit and sort", async () => {
-    mockedAxios.get.mockResolvedValueOnce({
+    mockedAxios.post.mockResolvedValueOnce({
       data: { total: 3, data: [1, 2, 3] }
     });
     const pagination = {
@@ -47,9 +45,11 @@ describe("ProductService - getProducts", () => {
       desc: true
     };
     await getProducts({ pagination, sort });
-    expect(mockedAxios.get).toBeCalledTimes(1);
-    expect(mockedAxios.get).toBeCalledWith("/product", {
-      params: { limit: 75, page: 1, sort: "-name" }
+    expect(mockedAxios.post).toBeCalledTimes(1);
+    expect(mockedAxios.post).toBeCalledWith("/product", {
+      limit: 75,
+      page: 1,
+      sort: "-name"
     });
   });
 });

--- a/packages/shopware-6-client/__tests__/settings.spec.ts
+++ b/packages/shopware-6-client/__tests__/settings.spec.ts
@@ -62,5 +62,11 @@ describe("Settings", () => {
       expect(config.accessToken).toEqual("SWSCBVBBZET1RTFIYWY4YVLICA");
       expect(config.contextToken).toEqual("");
     });
+
+    it("should change defaultPaginationLimit", () => {
+      update({ defaultPaginationLimit: 50 });
+      expect(config.accessToken).toEqual("SWSCBVBBZET1RTFIYWY4YVLICA");
+      expect(config.defaultPaginationLimit).toEqual(50);
+    });
   });
 });

--- a/packages/shopware-6-client/src/helpers/searchConverter.ts
+++ b/packages/shopware-6-client/src/helpers/searchConverter.ts
@@ -2,11 +2,16 @@ import { SearchCriteria } from "../interfaces/search/SearchCriteria";
 import { SearchFilter } from "../interfaces/search/SearchFilter";
 import { PaginationLimit } from "../interfaces/search/Pagination";
 
+interface ShopwareAssociation {
+  [name: string]: any;
+}
+
 export interface ShopwareParams {
   page?: number;
   limit?: number;
   sort?: string;
   filter?: SearchFilter[];
+  associations?: ShopwareAssociation;
 }
 // simple
 // const equals = {
@@ -61,7 +66,7 @@ export const convertSearchCriteria = (
   let params: ShopwareParams = {};
 
   if (!searchCriteria) return params;
-  const { filters, sort, pagination } = searchCriteria;
+  const { filters, sort, pagination, configuration } = searchCriteria;
 
   if (pagination) {
     const { limit, page } = pagination;
@@ -77,6 +82,17 @@ export const convertSearchCriteria = (
 
   if (filters && filters.length) {
     params.filter = filters;
+  }
+
+  if (configuration) {
+    const associations = configuration.associations;
+    if (associations && associations.length) {
+      let shopwareAssociations: ShopwareAssociation = {};
+      associations.forEach(association => {
+        shopwareAssociations[association.name] = {};
+      });
+      params.associations = shopwareAssociations;
+    }
   }
 
   return params;

--- a/packages/shopware-6-client/src/helpers/searchConverter.ts
+++ b/packages/shopware-6-client/src/helpers/searchConverter.ts
@@ -1,6 +1,7 @@
 import { SearchCriteria } from "../interfaces/search/SearchCriteria";
 import { SearchFilter } from "../interfaces/search/SearchFilter";
 import { PaginationLimit } from "../interfaces/search/Pagination";
+import { config } from "@shopware-pwa/shopware-6-client";
 
 interface ShopwareAssociation {
   [name: string]: any;
@@ -13,6 +14,7 @@ export interface ShopwareParams {
   filter?: SearchFilter[];
   associations?: ShopwareAssociation;
 }
+
 // simple
 // const equals = {
 //   type: "equals",
@@ -70,9 +72,12 @@ export const convertSearchCriteria = (
 
   if (pagination) {
     const { limit, page } = pagination;
-    if (page) params.page = page;
     if (limit && Object.values(PaginationLimit).includes(limit))
       params.limit = limit;
+    if (page) {
+      params.page = page;
+      if (!params.limit) params.limit = config.defaultPaginationLimit;
+    }
   }
 
   if (sort) {

--- a/packages/shopware-6-client/src/services/productService.ts
+++ b/packages/shopware-6-client/src/services/productService.ts
@@ -26,9 +26,10 @@ export const getProductsIds = async function(): Promise<
 export const getProducts = async function(
   searchCriteria?: SearchCriteria
 ): Promise<SearchResult<Product[]>> {
-  const resp = await apiService.get(`${getProductEndpoint()}`, {
-    params: convertSearchCriteria(searchCriteria)
-  });
+  const resp = await apiService.post(
+    `${getProductEndpoint()}`,
+    convertSearchCriteria(searchCriteria)
+  );
   return resp.data;
 };
 

--- a/packages/shopware-6-client/src/settings.ts
+++ b/packages/shopware-6-client/src/settings.ts
@@ -2,12 +2,14 @@ export interface ClientSettings {
   endpoint?: string;
   accessToken?: string;
   contextToken?: string;
+  defaultPaginationLimit?: number;
 }
 
 const defaultConfig: ClientSettings = {
   endpoint: "https://shopware-2.vuestorefront.io/sales-channel-api/v1",
   accessToken: "SWSCBVBBZET1RTFIYWY4YVLICA",
-  contextToken: ""
+  contextToken: "",
+  defaultPaginationLimit: 10
 };
 
 let clientConfig: ClientSettings = {};

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -11,27 +11,35 @@ yarn dev core --formats cjs
 __DEV__=false yarn dev
 ```
 */
-
+const fs = require("fs-extra");
+const path = require("path");
 const execa = require("execa");
 const { targets, fuzzyMatchTarget } = require("./utils");
 
 const args = require("minimist")(process.argv.slice(2));
-const target = args._.length ? fuzzyMatchTarget(args._)[0] : "client";
+const target = args._.length
+  ? fuzzyMatchTarget(args._)[0]
+  : "shopware-6-client";
 const formats = args.formats || args.f;
 const commit = execa.sync("git", ["rev-parse", "HEAD"]).stdout.slice(0, 7);
 
-execa(
-  "rollup",
-  [
-    "-wc",
-    "--environment",
+async function dev() {
+  const pkgDir = path.resolve(`packages/${target}`);
+  await fs.remove(`${pkgDir}/dist`);
+  execa(
+    "rollup",
     [
-      `COMMIT:${commit}`,
-      `TARGET:${target}`,
-      `FORMATS:${formats || "global"}`
-    ].join(",")
-  ],
-  {
-    stdio: "inherit"
-  }
-);
+      "-wc",
+      "--environment",
+      [
+        `COMMIT:${commit}`,
+        `TARGET:${target}`,
+        `FORMATS:${formats || "global"}`
+      ].join(",")
+    ],
+    {
+      stdio: "inherit"
+    }
+  );
+}
+dev();

--- a/test-page/src/views/Category.vue
+++ b/test-page/src/views/Category.vue
@@ -118,7 +118,7 @@
             v-for="(product, i) in products"
             :key="i"
             :title="product.name"
-            image="/img/product_thumb.png"
+            :image="product.media && product.media.length ? product.media[0].media.url : '/img/product_thumb.png'"
             :regular-price="product.calculatedPrice.unitPrice"
             :isOnWishlist="false"
             @click:wishlist="toggleWishlist(i)"
@@ -356,7 +356,9 @@ export default {
     };
   },
   async mounted() {
-    this.productsResponse = await getProducts();
+    this.productsResponse = await getProducts({
+      configuration: { associations: [{ name: "media" }] }
+    });
   },
   computed: {
     products() {

--- a/test-page/src/views/Category.vue
+++ b/test-page/src/views/Category.vue
@@ -118,7 +118,11 @@
             v-for="(product, i) in products"
             :key="i"
             :title="product.name"
-            :image="product.media && product.media.length ? product.media[0].media.url : '/img/product_thumb.png'"
+            :image="
+              product.media && product.media.length
+                ? product.media[0].media.url
+                : '/img/product_thumb.png'
+            "
             :regular-price="product.calculatedPrice.unitPrice"
             :isOnWishlist="false"
             @click:wishlist="toggleWishlist(i)"

--- a/test-page/src/views/Category.vue
+++ b/test-page/src/views/Category.vue
@@ -117,7 +117,7 @@
           <SfProductCard
             v-for="(product, i) in products"
             :key="i"
-            :title="product.name"
+            :title="product.name || ''"
             :image="
               product.media && product.media.length
                 ? product.media[0].media.url


### PR DESCRIPTION
1. availability to use `yarn dev:client` to develop locally and refresh page
2. added defaultPaginationLimit to config and using it when no limit is provided
3. changed getProducts to post
4. added associations in searchQuery
5. show product images on category page

Before merge: update readme.md to adjust for local coding