### PR TITLE
feat(cms): add text block handling

### DIFF
--- a/test-page/src/components/cms/cmsNameMapper.js
+++ b/test-page/src/components/cms/cmsNameMapper.js
@@ -7,7 +7,8 @@ const namesMap = {
   text: "SwSlots",
   "text-teaser": "SwSlots",
   "text-two-column": "SwSlots",
-  "text-three-column": "SwSlots"
+  "text-three-column": "SwSlots",
+  "text-teaser-section": "SwSlots"
 };
 
 const slotsMap = {

--- a/test-page/src/components/cms/cmsNameMapper.js
+++ b/test-page/src/components/cms/cmsNameMapper.js
@@ -3,13 +3,18 @@ const namesMap = {
   default: "SwSection",
   "product-slider": "SwSlots",
   "product-three-column": "SwSlots",
-  image: "SwSlots"
+  image: "SwSlots",
+  text: "SwSlots",
+  "text-teaser": "SwSlots",
+  "text-two-column": "SwSlots",
+  "text-three-column": "SwSlots"
 };
 
 const slotsMap = {
   "product-box": "CmsSwProductCart",
   "product-slider": "SwProductSlider",
-  image: "SwImage"
+  image: "SwImage",
+  text: "SwTextSlot"
 };
 
 export function getComponentBy(content) {

--- a/test-page/src/components/cms/elements/SwSlots.vue
+++ b/test-page/src/components/cms/elements/SwSlots.vue
@@ -4,6 +4,13 @@
       :content="cmsSlot"
       v-for="cmsSlot in cmsSlots"
       :key="cmsSlot.id"
+      v-bind:style="{ 
+          marginTop: marginTop,
+          marginBottom: marginBottom,
+          marginLeft: marginLeft,
+          marginRight: marginRight,
+          backgroundColor: backgroundColor
+       }"
     />
   </div>
 </template>
@@ -18,12 +25,53 @@ export default {
   props: {
     content: {
       type: Object,
-      default: () => ({})
+      default: () => ({
+        content: {
+          slots: [],
+          sectionId: null,
+          section: null,
+          position: null,
+          name: null,
+          sectionPosition: null,
+          marginTop: null,
+          marginBottom: null,
+          marginLeft: null,
+          marginRight: null,
+          backgroundColor: null,
+          backgroundMediaId: null,
+          backgroundMedia: null,
+          backgroundMediaMode: null,
+        }
+      })
     }
   },
   computed: {
     cmsSlots() {
       return this.content && this.content.slots ? this.content.slots : [];
+    },
+    marginTop() {
+      return this.content.marginTop 
+    },
+    marginBottom() {
+      return this.content.marginBottom
+    },
+    marginLeft() {
+      return this.content.marginLeft
+    },
+    marginRight() {
+      return this.content.marginRight
+    },
+    backgroundColor() {
+      return this.content.backgroundColor
+    },
+    backgroundMediaId() {
+      return this.content.backgroundMediaId
+    },
+    backgroundMedia() {
+      return this.content.backgroundMedia
+    },
+    backgroundMediaMode() {
+      return this.content.backgroundMediaMode
     }
   }
 };

--- a/test-page/src/components/cms/elements/SwTextSlot.vue
+++ b/test-page/src/components/cms/elements/SwTextSlot.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="sw-text">
+    <div class="sw-text-content" :id="slotId" v-html="rawHtml">
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  components: {
+  },
+  props: {
+    content: {
+      type: Object,
+      default: () => ({
+        config: {
+          content: {
+            value: ""
+          },
+          verticalAlign: {
+            value: null
+          }
+        },
+        id: null,
+      })
+    }
+  },
+  computed: {
+    rawHtml() {
+      return this.content.config.content.value
+    },
+    slotId() {
+      return this.content.id
+    },
+    verticalAlign() {
+      return this.content.config.verticalAlign.value
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+</style>


### PR DESCRIPTION
Adds component handling for this type of blocks:
- text-teaser
- text-two-column
- text-three-column

and text slot type.

it outputs a raw HTML that comes from the API. 