### PR TITLE
Fix/category default query params

### DIFF
--- a/packages/composables/src/hooks/useProductListing.ts
+++ b/packages/composables/src/hooks/useProductListing.ts
@@ -61,16 +61,12 @@ export const useProductListing = (
   sharedListing.products = initialProducts;
   selectedCriteria.sorting = activeSorting.value;
 
-  const resetFilters = async () => {
+  const resetFilters = () => {
     selectedCriteria.filters = {};
   };
 
-  const resetSorting = async () => {
+  const resetSorting = () => {
     selectedCriteria.sorting = activeSorting.value;
-  };
-
-  const resetPagination = async () => {
-    selectedCriteria.pagination = {};
   };
 
   const toggleFilter = (
@@ -159,14 +155,14 @@ export const useProductListing = (
     await search();
   };
 
-  if (sharedListing.products.length) {
+  // if reloaded on route change
+  if (initialProducts.length) {
     resetFilters();
     resetSorting();
-    resetPagination();
-    search();
+    changePagination(1);
   }
 
-  const pagination: any = computed(() => sharedPagination);
+  const pagination: any = computed(() => localPagination);
   const products = computed(() => localListing.products);
   const productsTotal = computed(() => localPagination.total);
   const selectedFilters = computed(() => localCriteria.filters);

--- a/packages/default-theme/components/cms/elements/SwCategorySidebarFilter.vue
+++ b/packages/default-theme/components/cms/elements/SwCategorySidebarFilter.vue
@@ -139,6 +139,7 @@ export default {
   },
   watch: {
     sortBy(newSorting, oldOne){
+      // prevent reloading on default sorting
       if (oldOne.name !== newSorting.name) {
         this.changeSorting(newSorting)
       }

--- a/packages/default-theme/components/cms/elements/SwCategorySidebarFilter.vue
+++ b/packages/default-theme/components/cms/elements/SwCategorySidebarFilter.vue
@@ -138,8 +138,10 @@ export default {
     }
   },
   watch: {
-    sortBy(value){
-      this.changeSorting(value)
+    sortBy(newSorting, oldOne){
+      if (oldOne.name !== newSorting.name) {
+        this.changeSorting(newSorting)
+      }
     }
   },
   computed: {


### PR DESCRIPTION
- proper pagination reset


TODO: add **total** property within the category's product listing to show correct pagination without calling the /product endpoint.