### PR TITLE
feat: use navigation urls taken from API

### DIFF
--- a/api/helpers.api.md
+++ b/api/helpers.api.md
@@ -6,6 +6,7 @@
 
 import { CmsPage } from '@shopware-pwa/shopware-6-client/src/interfaces/models/content/cms/CmsPage';
 import { CmsSection } from '@shopware-pwa/shopware-6-client/src/interfaces/models/content/cms/CmsPage';
+import { NavigationElement } from '@shopware-pwa/shopware-6-client/src/interfaces/models/content/navigation/Navigation';
 import { Product } from '@shopware-pwa/shopware-6-client/src/interfaces/models/content/product/Product';
 import { PropertyGroupOption } from '@shopware-pwa/shopware-6-client/src/interfaces/models/content/property/PropertyGroupOption';
 import { SearchCriteria } from '@shopware-pwa/shopware-6-client/src/interfaces/search/SearchCriteria';
@@ -67,6 +68,11 @@ export function getCmsSections(content: CmsPage): CmsSection[];
 
 // @alpha (undocumented)
 export const getFilterSearchCriteria: (selectedFilters: any) => any[];
+
+// Warning: (ae-forgotten-export) The symbol "NavigationRoute" needs to be exported by the entry point index.d.ts
+//
+// @alpha (undocumented)
+export function getNavigationRoutes(navigationElements: NavigationElement[]): NavigationRoute[];
 
 // @alpha (undocumented)
 export function getProductMainImageUrl({ product }?: {

--- a/api/shopware-6-client.api.md
+++ b/api/shopware-6-client.api.md
@@ -14,6 +14,7 @@ import { Customer } from '@shopware-pwa/shopware-6-client/src/interfaces/models/
 import { CustomerAddress } from '@shopware-pwa/shopware-6-client/src/interfaces/models/checkout/customer/CustomerAddress';
 import { CustomerRegistrationParams } from '@shopware-pwa/shopware-6-client/src/interfaces/request/CustomerRegistrationParams';
 import { Language } from '@shopware-pwa/shopware-6-client/src/interfaces/models/framework/language/Language';
+import { NavigationResponse } from '@shopware-pwa/shopware-6-client/src/interfaces/models/content/navigation/Navigation';
 import { Order } from '@shopware-pwa/shopware-6-client/src/interfaces/models/checkout/order/Order';
 import { PaymentMethod } from '@shopware-pwa/shopware-6-client/src/interfaces/models/checkout/payment/PaymentMethod';
 import { Product } from '@shopware-pwa/shopware-6-client/src/interfaces/models/content/product/Product';
@@ -165,32 +166,6 @@ export function login({ username, password }?: {
 
 // @alpha
 export function logout(): Promise<void>;
-
-// @alpha (undocumented)
-export interface NavigationElement {
-    // (undocumented)
-    children: NavigationElement[] | null;
-    // (undocumented)
-    count: number;
-    // (undocumented)
-    extensions: any[];
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    level: number;
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    path: string;
-}
-
-// @alpha (undocumented)
-export interface NavigationResponse {
-    // (undocumented)
-    children: NavigationElement[];
-    // (undocumented)
-    count: number;
-}
 
 // @alpha (undocumented)
 export function onConfigChange(fn: (context: ConfigChangedArgs) => void): void;

--- a/packages/composables/__tests__/useNavigation.spec.ts
+++ b/packages/composables/__tests__/useNavigation.spec.ts
@@ -8,45 +8,37 @@ const mockedGetPage = shopwareClient as jest.Mocked<typeof shopwareClient>;
 
 describe("Composables - useNavigation", () => {
   describe("computed", () => {
-    describe("routeNames", () => {
+    describe("routes", () => {
       it("should get null when routeNames are not fetched", () => {
-        const { routeNames } = useNavigation();
-        expect(routeNames.value).toBe(null);
+        const { routes } = useNavigation();
+        expect(routes.value).toBe(null);
       });
     });
   });
 
   describe("methods", () => {
-    describe("fetchRouteNames", () => {
-      it("should routeNames set to null when navigation data are not fetched", async () => {
+    describe("fetchRoutes", () => {
+      it("should routes set to null when navigation data are not fetched", async () => {
         mockedGetPage.getNavigation.mockResolvedValueOnce({} as any);
-        const { routeNames, fetchRouteNames } = useNavigation();
-        await fetchRouteNames();
-        expect(routeNames.value).toBe(null);
+        const { routes, fetchRoutes } = useNavigation();
+        await fetchRoutes();
+        expect(routes.value).toBe(null);
       });
-      it("should fetch routeNames correcly", async () => {
+      it("should fetch routes correcly", async () => {
         mockedGetPage.getNavigation.mockResolvedValueOnce({
           count: 3,
-          children: [{ name: "test1" }, { name: "test2" }, { name: "test3" }]
+          children: [
+            { name: "Clothin", route: { path: "clothing/" } },
+            { name: "Sports", route: { path: "sports/" } },
+            {
+              name: "Accessories & Others",
+              route: { path: "accessories-others/" }
+            }
+          ]
         } as any);
-        const { routeNames, fetchRouteNames } = useNavigation();
-        await fetchRouteNames();
-        expect(routeNames.value).toEqual(["test1", "test2", "test3"]);
-      });
-    });
-
-    describe("convertToSlug", () => {
-      it("should return empty string when nothing provided in prams", () => {
-        const { convertToSlug } = useNavigation();
-        expect(convertToSlug()).toEqual("");
-      });
-      it("should convert string without space to slug correcly", () => {
-        const { convertToSlug } = useNavigation();
-        expect(convertToSlug("test")).toEqual("/test/");
-      });
-      it("should convert string with spaces to slug correcly", () => {
-        const { convertToSlug } = useNavigation();
-        expect(convertToSlug("test test")).toEqual("/test-test/");
+        const { routes, fetchRoutes } = useNavigation();
+        await fetchRoutes();
+        expect(routes.value).toHaveLength(3);
       });
     });
   });

--- a/packages/composables/src/hooks/useNavigation.ts
+++ b/packages/composables/src/hooks/useNavigation.ts
@@ -1,33 +1,23 @@
 import Vue from "vue";
 import { reactive, computed } from "@vue/composition-api";
 import { getNavigation } from "@shopware-pwa/shopware-6-client";
+import { getNavigationRoutes } from "@shopware-pwa/helpers";
 
 const sharedNavigation = Vue.observable({
-  routeNames: null
+  routes: null
 } as any);
 export const useNavigation = (): any => {
   const localNavigation = reactive(sharedNavigation);
-  const routeNames = computed(() => localNavigation.routeNames);
+  const routes = computed(() => localNavigation.routes);
 
-  const fetchRouteNames = async (params?: any): Promise<void> => {
+  const fetchRoutes = async (params?: any): Promise<void> => {
     const navigation = await getNavigation(params);
     if (typeof navigation.children === "undefined") return;
-    sharedNavigation.routeNames = navigation.children.map(
-      (element: { name: string }) => element.name
-    );
-  };
-
-  const convertToSlug = (name: string): string => {
-    if (typeof name !== "string") {
-      return "";
-    }
-    const slug = name.replace(" ", "-");
-    return `\/${slug.toLowerCase()}\/`;
+    sharedNavigation.routes = getNavigationRoutes(navigation.children);
   };
 
   return {
-    routeNames,
-    fetchRouteNames,
-    convertToSlug
+    routes,
+    fetchRoutes
   };
 };

--- a/packages/composables/src/hooks/useUser.ts
+++ b/packages/composables/src/hooks/useUser.ts
@@ -3,7 +3,7 @@ import {
   login as apiLogin,
   logout as apiLogout,
   register as apiRegister,
-  updatePassword as  apiUpdatePassword,
+  updatePassword as apiUpdatePassword,
   updateEmail as apiUpdateEmail,
   getCustomer,
   getCustomerOrders,
@@ -15,7 +15,7 @@ import {
   updateProfile,
   CustomerUpdateProfileParam,
   CustomerUpdatePasswordParam,
-  CustomerUpdateEmailParam,
+  CustomerUpdateEmailParam
 } from "@shopware-pwa/shopware-6-client";
 import { Customer } from "@shopware-pwa/shopware-6-client/src/interfaces/models/checkout/customer/Customer";
 import { getStore } from "@shopware-pwa/composables";
@@ -51,9 +51,13 @@ export interface UseUser {
   getOrderDetails: (orderId: string) => Promise<Order>;
   loadAddresses: () => Promise<void>;
   deleteAddress: (addressId: string) => Promise<boolean>;
-  updatePersonalInfo: (personals: CustomerUpdateProfileParam) => Promise<boolean>;
+  updatePersonalInfo: (
+    personals: CustomerUpdateProfileParam
+  ) => Promise<boolean>;
   updateEmail: (updateEmailData: CustomerUpdateEmailParam) => Promise<boolean>;
-  updatePassword: (updatePasswordData: CustomerUpdatePasswordParam) => Promise<boolean>;
+  updatePassword: (
+    updatePasswordData: CustomerUpdatePasswordParam
+  ) => Promise<boolean>;
   markAddressAsDefault: ({
     addressId,
     type
@@ -191,32 +195,38 @@ export const useUser = (): UseUser => {
     return false;
   };
 
-  const updatePersonalInfo = async (personals: CustomerUpdateProfileParam): Promise<boolean> => {
+  const updatePersonalInfo = async (
+    personals: CustomerUpdateProfileParam
+  ): Promise<boolean> => {
     try {
       await updateProfile(personals);
     } catch (e) {
-      error.value = e;
-      return false;
-    } 
-    return true;
-  };
-
-  const updatePassword = async (updatePasswordData: CustomerUpdatePasswordParam): Promise<boolean> => {
-    try {
-      await apiUpdatePassword(updatePasswordData);
-    } catch(e) {
       error.value = e;
       return false;
     }
     return true;
   };
 
-  const updateEmail = async (updateEmailData: CustomerUpdateEmailParam): Promise<boolean> => {
+  const updatePassword = async (
+    updatePasswordData: CustomerUpdatePasswordParam
+  ): Promise<boolean> => {
+    try {
+      await apiUpdatePassword(updatePasswordData);
+    } catch (e) {
+      error.value = e;
+      return false;
+    }
+    return true;
+  };
+
+  const updateEmail = async (
+    updateEmailData: CustomerUpdateEmailParam
+  ): Promise<boolean> => {
     try {
       await apiUpdateEmail(updateEmailData);
-    } catch(e) {
+    } catch (e) {
       error.value = e;
-      return false
+      return false;
     }
     return true;
   };

--- a/packages/default-theme/components/SwBottomNavigation.vue
+++ b/packages/default-theme/components/SwBottomNavigation.vue
@@ -9,8 +9,8 @@
       <SfBottomNavigationItem class="menu-button">
         <SfIcon icon="menu" size="20px" style="width: 25px" />
         <SfSelect class="menu-button__select">
-          <SfSelectOption v-for="routeName in routeNames" :key="routeName">
-              <SfProductOption @click="changeRoute(convertToSlug(routeName))">{{routeName}}</SfProductOption>
+          <SfSelectOption v-for="{routeLabel, routePath } in routes" :key="routeLabel">
+              <SfProductOption @click="changeRoute(routePath)">{{routeLabel}}</SfProductOption>
           </SfSelectOption>
         </SfSelect>
       </SfBottomNavigationItem>
@@ -46,19 +46,18 @@ export default {
   },
   setup() {
     const { toggleSidebar, isSidebarOpen } = useCartSidebar()
-    const { routeNames, convertToSlug } = useNavigation()
+    const { routes } = useNavigation()
     const { toggleModal } = useUserLoginModal()
     return {
-      routeNames,
+      routes,
       isSidebarOpen,
-      convertToSlug,
       toggleSidebar,
       toggleModal
     }
   },
   methods: {
-    changeRoute(name) {
-      this.$router.push(name)
+    changeRoute(path) {
+      this.$router.push(`/${path}`)
     },
   }
 }

--- a/packages/default-theme/components/TopNavigation.vue
+++ b/packages/default-theme/components/TopNavigation.vue
@@ -71,7 +71,6 @@
 </template>
 
 <script>
-import slugify from 'slugify' // TODO: remove after the navigation is fully implemented
 import { SfHeader, SfCircleIcon, SfBadge, SfImage } from '@storefront-ui/vue'
 import {
   useUser,

--- a/packages/default-theme/components/TopNavigation.vue
+++ b/packages/default-theme/components/TopNavigation.vue
@@ -19,11 +19,11 @@
             <SfHeaderNavigationItem>Home</SfHeaderNavigationItem>
           </nuxt-link>
           <nuxt-link
-            v-for="routeName in routeNames"
-            :key="routeName"
-            :to="convertToSlug(routeName)"
+            v-for="{routeLabel, routePath } in routes"
+            :key="routePath"
+            :to="routePath"
           >
-            <SfHeaderNavigationItem>{{ routeName }}</SfHeaderNavigationItem>
+            <SfHeaderNavigationItem>{{ routeLabel }}</SfHeaderNavigationItem>
           </nuxt-link>
         </template>
 
@@ -85,16 +85,15 @@ import SwLoginModal from './modals/SwLoginModal'
 export default {
   components: { SfHeader, SfCircleIcon, SfBadge, SwLoginModal, SfImage },
   setup() {
-    const { convertToSlug, routeNames, fetchRouteNames } = useNavigation()
+    const { routes, fetchRoutes } = useNavigation()
     const { isLoggedIn, logout } = useUser()
     const { count } = useCart()
     const { toggleSidebar } = useCartSidebar()
     const { toggleModal } = useUserLoginModal()
 
     return {
-      routeNames,
-      fetchRouteNames,
-      convertToSlug,
+      routes,
+      fetchRoutes,
       count,
       toggleModal,
       toggleSidebar,
@@ -111,7 +110,7 @@ export default {
     }
   },
   async mounted() {
-    await this.fetchRouteNames({depth: 1})
+    await this.fetchRoutes({depth: 1})
   },
   methods: {
     async userIconClick() {

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -30,7 +30,6 @@
     "currency.js": "^1.2.2",
     "dayjs": "^1.8.19",
     "nuxt": "^2.11.0",
-    "slugify": "^1.3.6",
     "vuelidate": "^0.7.5"
   },
   "devDependencies": {

--- a/packages/helpers/__tests__/navigation/getNavigationRoutes.spec.ts
+++ b/packages/helpers/__tests__/navigation/getNavigationRoutes.spec.ts
@@ -1,0 +1,57 @@
+import { getNavigationRoutes } from "@shopware-pwa/helpers";
+describe("Shopware helpers - navigation", () => {
+  describe("getNavigationRoutes", () => {
+    it("should return an array with one object with no children included", () => {
+      const SWNavigationResponse = [
+        {
+          name: "Cloting",
+          route: {
+            path: "clothing/"
+          },
+          children: null
+        }
+      ];
+
+      const result = getNavigationRoutes(SWNavigationResponse as any);
+
+      expect(result).toStrictEqual([
+        { routeLabel: "Cloting", routePath: "clothing/", children: null }
+      ]);
+    });
+
+    it("should return an array with one object with children included", () => {
+      const SWNavigationResponse = [
+        {
+          name: "Cloting",
+          route: {
+            path: "clothing/"
+          },
+          children: [
+            {
+              name: "Outdoor",
+              route: {
+                path: "clothing/outdoor/"
+              }
+            }
+          ]
+        }
+      ];
+
+      const result = getNavigationRoutes(SWNavigationResponse as any);
+
+      expect(result).toStrictEqual([
+        {
+          routeLabel: "Cloting",
+          routePath: "clothing/",
+          children: [
+            {
+              children: undefined,
+              routeLabel: "Outdoor",
+              routePath: "clothing/outdoor/"
+            }
+          ]
+        }
+      ]);
+    });
+  });
+});

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -4,3 +4,4 @@ export * from "./ui-interfaces";
 export * from "./cms";
 export * from "./urlHelpers";
 export * from "./listing";
+export * from "./navigation";

--- a/packages/helpers/src/navigation/getNavigationRoutes.ts
+++ b/packages/helpers/src/navigation/getNavigationRoutes.ts
@@ -1,0 +1,25 @@
+import { NavigationElement as SwNavigationElement } from "@shopware-pwa/shopware-6-client/src/interfaces/models/content/navigation/Navigation";
+
+interface NavigationRoute {
+  routeLabel: string;
+  routePath: string;
+}
+
+/**
+ * @alpha
+ */
+export function getNavigationRoutes(
+  navigationElements: SwNavigationElement[]
+): NavigationRoute[] {
+  return navigationElements.map(
+    (element: {
+      children: SwNavigationElement[] | null;
+      name: string;
+      route: { path: string; resourceType: string };
+    }) => ({
+      routeLabel: element.name,
+      routePath: element.route.path,
+      children: element.children && getNavigationRoutes(element.children)
+    })
+  );
+}

--- a/packages/helpers/src/navigation/index.ts
+++ b/packages/helpers/src/navigation/index.ts
@@ -1,0 +1,1 @@
+export * from "./getNavigationRoutes";

--- a/packages/shopware-6-client/src/interfaces/models/checkout/customer/CustomerAddress.ts
+++ b/packages/shopware-6-client/src/interfaces/models/checkout/customer/CustomerAddress.ts
@@ -1,5 +1,5 @@
-import { Country } from "../../system/country/Country";
-import { CustomField } from "../../common/CustomField";
+import { Country } from "@shopware-pwa/shopware-6-client/src/interfaces/models/system/country/Country";
+import { CustomField } from "@shopware-pwa/shopware-6-client/src/interfaces/models/common/CustomField";
 
 export enum AddressType {
   billing = "billing",

--- a/packages/shopware-6-client/src/interfaces/models/content/navigation/Navigation.ts
+++ b/packages/shopware-6-client/src/interfaces/models/content/navigation/Navigation.ts
@@ -1,0 +1,23 @@
+/**
+ * @alpha
+ */
+export interface NavigationResponse {
+  count: number;
+  children: NavigationElement[];
+}
+
+/**
+ * @alpha
+ */
+export interface NavigationElement {
+  id: string;
+  name: string;
+  route: {
+    path: string;
+    resourceType: string;
+  };
+  children: NavigationElement[] | null;
+  count: number;
+  level: number;
+  extensions: any[];
+}

--- a/packages/shopware-6-client/src/services/cartService.ts
+++ b/packages/shopware-6-client/src/services/cartService.ts
@@ -17,7 +17,7 @@ import { CartItemType } from "@shopware-pwa/shopware-6-client/src/interfaces/car
  * As the purpose of this method is not clear we recommend to use getCart() method because its behaviour seems to be the same.
  *
  * @throws ClientApiError
- * 
+ *
  * @alpha
  */
 export async function clearCart(): Promise<ContextTokenResponse> {

--- a/packages/shopware-6-client/src/services/navigationService.ts
+++ b/packages/shopware-6-client/src/services/navigationService.ts
@@ -1,6 +1,6 @@
 import { getNavigationEndpoint } from "../endpoints";
 import { apiService } from "../apiService";
-import { NavigationResponse } from "../interfaces/models/content/navigation/Navigation";
+import { NavigationResponse } from "@shopware-pwa/shopware-6-client/src/interfaces/models/content/navigation/Navigation";
 
 /**
  * @alpha

--- a/packages/shopware-6-client/src/services/navigationService.ts
+++ b/packages/shopware-6-client/src/services/navigationService.ts
@@ -1,26 +1,6 @@
 import { getNavigationEndpoint } from "../endpoints";
 import { apiService } from "../apiService";
-
-/**
- * @alpha
- */
-export interface NavigationResponse {
-  count: number;
-  children: NavigationElement[];
-}
-
-/**
- * @alpha
- */
-export interface NavigationElement {
-  id: string;
-  path: string;
-  name: string;
-  children: NavigationElement[] | null;
-  count: number;
-  level: number;
-  extensions: any[];
-}
+import { NavigationResponse } from "../interfaces/models/content/navigation/Navigation";
 
 /**
  * @alpha

--- a/yarn.lock
+++ b/yarn.lock
@@ -13748,11 +13748,6 @@ slide@^1.1.6:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
-slugify@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.6.tgz#ba5fd6159b570fe4811d02ea9b1f4906677638c3"
-  integrity sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ==
-
 smart-buffer@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"


### PR DESCRIPTION
<!-- 
write which issue this pull request closes
  example: closes #230
-->
closes #365 

keep in mind: technical URLs will be replaced with the pretty URLs once it's handled on API side.

## Changes
<!-- List all the changes that you did -->
- new helper to convert navigation from SW API
- add recursion to navi children elements
- not use the slugify anymore: removed from packages
- navigation converter moved from composable "useNavigation"
- some tiny refactor changes

## Screenshots of visual changes

## Checklist

- [x] I followed code and contributing guidelines
- [x] I wrote all needed tests
