### PR TITLE
fix(helpers): prefix route path with slash

### DIFF
--- a/packages/helpers/__tests__/navigation/getNavigationRoutes.spec.ts
+++ b/packages/helpers/__tests__/navigation/getNavigationRoutes.spec.ts
@@ -1,6 +1,23 @@
 import { getNavigationRoutes } from "@shopware-pwa/helpers";
 describe("Shopware helpers - navigation", () => {
   describe("getNavigationRoutes", () => {
+    it("should return technical url without prefixing by slash if it exists already", () => {
+      const SWNavigationResponse = [
+        {
+          name: "Cloting",
+          route: {
+            path: "/navigation/7d4c679c61d5aa387c80a6a45d75c117"
+          },
+          children: null
+        }
+      ];
+
+      const result = getNavigationRoutes(SWNavigationResponse as any);
+
+      expect(result).toStrictEqual([
+        { routeLabel: "Cloting", routePath: "/navigation/7d4c679c61d5aa387c80a6a45d75c117", children: null }
+      ]);
+    });
     it("should return an array with one object with no children included", () => {
       const SWNavigationResponse = [
         {

--- a/packages/helpers/__tests__/navigation/getNavigationRoutes.spec.ts
+++ b/packages/helpers/__tests__/navigation/getNavigationRoutes.spec.ts
@@ -15,7 +15,7 @@ describe("Shopware helpers - navigation", () => {
       const result = getNavigationRoutes(SWNavigationResponse as any);
 
       expect(result).toStrictEqual([
-        { routeLabel: "Cloting", routePath: "clothing/", children: null }
+        { routeLabel: "Cloting", routePath: "/clothing/", children: null }
       ]);
     });
 
@@ -42,12 +42,12 @@ describe("Shopware helpers - navigation", () => {
       expect(result).toStrictEqual([
         {
           routeLabel: "Cloting",
-          routePath: "clothing/",
+          routePath: "/clothing/",
           children: [
             {
               children: undefined,
               routeLabel: "Outdoor",
-              routePath: "clothing/outdoor/"
+              routePath: "/clothing/outdoor/"
             }
           ]
         }

--- a/packages/helpers/src/navigation/getNavigationRoutes.ts
+++ b/packages/helpers/src/navigation/getNavigationRoutes.ts
@@ -18,7 +18,7 @@ export function getNavigationRoutes(
       route: { path: string; resourceType: string };
     }) => ({
       routeLabel: element.name,
-      routePath: element.route.path,
+      routePath: `/${element.route.path}`,
       children: element.children && getNavigationRoutes(element.children)
     })
   );

--- a/packages/helpers/src/navigation/getNavigationRoutes.ts
+++ b/packages/helpers/src/navigation/getNavigationRoutes.ts
@@ -18,7 +18,7 @@ export function getNavigationRoutes(
       route: { path: string; resourceType: string };
     }) => ({
       routeLabel: element.name,
-      routePath: `/${element.route.path}`,
+      routePath: element.route.path.charAt(0) !== '/' ? `/${element.route.path}` : element.route.path,
       children: element.children && getNavigationRoutes(element.children)
     })
   );


### PR DESCRIPTION
<!-- 
write which issue this pull request closes
  example: closes #230
-->
It prevents getting wrong urls nesting on route's change. 

## Changes
<!-- List all the changes that you did -->
- add slash prefix before each given route path
- only helper is affected by this change

## Screenshots of visual changes

## Checklist

- [x] I followed code and contributing guidelines
- [x] I wrote all needed tests
