### PR TITLE
fix(theme): increase z-index for login modal

### DIFF
--- a/packages/default-theme/components/modals/SwLoginModal.vue
+++ b/packages/default-theme/components/modals/SwLoginModal.vue
@@ -116,13 +116,13 @@ export default {
 }
 
 #sw-login-modal {
-  z-index: 2;
   box-sizing: border-box;
   @include for-desktop {
     max-width: 80vw;
     margin: auto;
   }
 }
+
 .input-group {
   display: flex;
   width: 30vw;
@@ -143,10 +143,12 @@ export default {
     margin-top: $spacer-big;
   }
 }
+
 .action {
   margin-top: $spacer-big;
   text-align: center;
 }
+
 .bottom {
   padding-top: $spacer-extra-big;
   margin-top: $spacer-extra-big;
@@ -154,10 +156,16 @@ export default {
   line-height: 1.6;
   text-align: center;
 }
+
 .sf-button--muted {
   color: $c-text-muted;
 }
+
 .salutation {
   width: 8vw;
+}
+
+::v-deep .sf-modal__container {
+  z-index: 3;
 }
 </style>


### PR DESCRIPTION
closes #435 

## Changes
- remove unused z-index from #sw-login-modal
- add z-index to .sf-modal__content to fix the bug

## Checklist

- [x] I followed code and contributing guidelines
- [x] I wrote all needed tests
