### PR TITLE
fix(theme): fox wrong product tile size

### DIFF
--- a/packages/default-theme/components/cms/elements/SwProductListingSlot.vue
+++ b/packages/default-theme/components/cms/elements/SwProductListingSlot.vue
@@ -136,6 +136,7 @@ $col-prod-1: 1 0 $mx-photo-wth-1;
   ::v-deep &__wrapper {
     display: flex;
     flex-direction: column;
+    width: 100%;
   }
 
   &__list {


### PR DESCRIPTION
closes #443 

## Changes
<!-- List all the changes that you did -->
Fix product tile size
## Screenshots of visual changes
Before: 
![Adnotacja 2020-03-10 111639](https://user-images.githubusercontent.com/32803679/76303239-b39f6780-62c1-11ea-8ada-0a83f9f4cc12.png)
After:
![Adnotacja 2020-03-10 112039](https://user-images.githubusercontent.com/32803679/76303267-ba2ddf00-62c1-11ea-8292-818de9026a8c.png)


## Checklist

- [x] I followed code and contributing guidelines
- [] I wrote all needed tests
