### PR TITLE
fix(theme): fix positioning of result text

### DIFF
--- a/packages/default-theme/components/cms/elements/SwProductListingSlot.vue
+++ b/packages/default-theme/components/cms/elements/SwProductListingSlot.vue
@@ -227,5 +227,6 @@ $col-prod-1: 1 0 $mx-photo-wth-1;
 ::v-deep .sf-loader {
   width: 100%;
   display: flex;
+  justify-content: center;
 }
 </style>


### PR DESCRIPTION
closes #445 

## Changes
<!-- List all the changes that you did -->
Center result text when there are no results.

## Screenshots of visual changes
Before:
![Adnotacja 2020-03-10 112039](https://user-images.githubusercontent.com/32803679/76308130-6d023b00-62ca-11ea-8f5b-d98b57a3797f.png)

After:
![Adnotacja 2020-03-10 111639](https://user-images.githubusercontent.com/32803679/76308141-71c6ef00-62ca-11ea-9825-14ffc87b91ed.png)

## Checklist

- [x] I followed code and contributing guidelines
- [] I wrote all needed tests
