### PR TITLE
fix: change way of displaying breadcrumbs and plugin top navigation

### DIFF
--- a/packages/default-theme/components/TopNavigation.vue
+++ b/packages/default-theme/components/TopNavigation.vue
@@ -136,8 +136,8 @@ export default {
 @import '~@storefront-ui/vue/styles.scss';
 
 .top-navigation {
+  margin-bottom: var(--spacer-medium);
   @include for-desktop {
-    margin-bottom: var(--spacer-medium);
 
     .sf-header {
       display: flex;

--- a/packages/default-theme/layouts/default.vue
+++ b/packages/default-theme/layouts/default.vue
@@ -1,13 +1,15 @@
 <template>
   <div class="layout">
     <TopNavigation />
-    <SwPluginTopNavigation />
-    <SfBreadcrumbs
-      v-show="getBreadcrumbs.length > 0"
-      :breadcrumbs="getBreadcrumbs"
-      class="sw-breadcrumbs"
-      @click="redirectTo"
-    />
+    <div class="layout__top-navigation">
+      <SfBreadcrumbs
+        v-show="getBreadcrumbs.length > 0"
+        :breadcrumbs="getBreadcrumbs"
+        class="sw-breadcrumbs"
+        @click="redirectTo"
+      />
+      <SwPluginTopNavigation />
+    </div>
     <nuxt />
     <SwCart />
     <SwBottomNavigation class="layout__bottom-navigation" />
@@ -146,6 +148,15 @@ body {
   height: 100%;
   display: flex;
   flex-direction: column;
+
+  &__top-navigation {
+    display: flex;
+    flex-direction: column;
+    @include for-desktop {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+  }
 
   &__bottom-navigation {
     @include for-desktop() {

--- a/packages/default-theme/layouts/default.vue
+++ b/packages/default-theme/layouts/default.vue
@@ -1,15 +1,13 @@
 <template>
   <div class="layout">
     <TopNavigation />
-    <div class="layout__top-navigation">
-      <SfBreadcrumbs
-        v-show="getBreadcrumbs.length > 0"
-        :breadcrumbs="getBreadcrumbs"
-        class="sw-breadcrumbs"
-        @click="redirectTo"
-      />
-      <SwPluginTopNavigation />
-    </div>
+    <SwPluginTopNavigation />
+    <SfBreadcrumbs
+      v-show="getBreadcrumbs.length > 0"
+      :breadcrumbs="getBreadcrumbs"
+      class="sw-breadcrumbs"
+      @click="redirectTo"
+    />
     <nuxt />
     <SwCart />
     <SwBottomNavigation class="layout__bottom-navigation" />
@@ -149,15 +147,6 @@ body {
   display: flex;
   flex-direction: column;
 
-  &__top-navigation {
-    display: flex;
-    flex-direction: column;
-    @include for-desktop {
-      flex-direction: row;
-      justify-content: space-between;
-    }
-  }
-
   &__bottom-navigation {
     @include for-desktop() {
       display: none;
@@ -166,7 +155,7 @@ body {
 }
 
 .sw-breadcrumbs {
-  padding: var(--spacer-big) var(--spacer-extra-big) var(--spacer-extra-big);
+  padding: 0 var(--spacer-extra-big) var(--spacer-extra-big) var(--spacer-extra-big);
 }
 
 /* Delete firefox outline */


### PR DESCRIPTION
closes: #503 

## Changes
Change the way of displaying breadcrumbs and plugin top navigation

## Screenshots of visual changes

Before: 
![image](https://user-images.githubusercontent.com/32803679/76960552-fbef0300-691b-11ea-9f5e-0e935320cd1b.png)
After:
![image](https://user-images.githubusercontent.com/32803679/76960570-027d7a80-691c-11ea-9727-6dee93d67bf9.png)

## Checklist

- [x] I followed code and contributing guidelines
- [] I wrote all needed tests
