### PR TITLE
feat: prevent redirecting on api client rejection

### DIFF
--- a/packages/composables/__tests__/useUser.spec.ts
+++ b/packages/composables/__tests__/useUser.spec.ts
@@ -73,8 +73,16 @@ describe("Composables - useUser", () => {
         await refreshUser();
         expect(user.value).toEqual({ id: "123" });
       });
+      it("should not set user on getCustomer request's rejection", async () => {
+        mockedApiClient.getCustomer.mockRejectedValueOnce({
+          message: "Some error"
+        } as any);
+        const { user, refreshUser } = useUser();
+        await refreshUser();
+        expect(user.value).toBeNull();
+        expect(stateUser.value).toBeNull();
+      });
     });
-
     describe("login", () => {
       it("should not login user without credentials", async () => {
         mockedApiClient.login.mockRejectedValueOnce(

--- a/packages/composables/src/hooks/useUser.ts
+++ b/packages/composables/src/hooks/useUser.ts
@@ -131,8 +131,12 @@ export const useUser = (): UseUser => {
   };
 
   const refreshUser = async (): Promise<void> => {
-    const user = await getCustomer();
-    vuexStore.commit("SET_USER", user);
+    try {
+      const user = await getCustomer();
+      vuexStore.commit("SET_USER", user);
+    } catch (e) {
+      console.error("useUser:refreshUser:getCustomer", e);
+    }
   };
 
   const loadOrders = async (): Promise<void> => {

--- a/packages/default-theme/components/SwProductCarousel.vue
+++ b/packages/default-theme/components/SwProductCarousel.vue
@@ -34,17 +34,21 @@ export default {
     }
   },
   async mounted() {
-    const result = await getProducts({
-      sort: {
-        field: 'price',
-        desc: false
-      },
-      pagination: {
-        page: 1,
-        limit: 10
-      }
-    })
-    this.products = result.data
+    try {
+      const result = await getProducts({
+        sort: {
+          field: 'price',
+          desc: false
+        },
+        pagination: {
+          page: 1,
+          limit: 10
+        }
+      })
+      this.products = result.data
+    } catch (e) {
+      console.error('SwProductCarousel:mounted:getProducts', e)
+    }
   }
 }
 </script>

--- a/packages/default-theme/components/views/ProductView.vue
+++ b/packages/default-theme/components/views/ProductView.vue
@@ -100,10 +100,13 @@ export default {
       'associations[children][associations][options][associations][group][]': true,
       'associations[children][associations][seoUrls][]': true
     }
-
-    const { loadAssociations, product } = useProduct(this.page.product)
-    this.productWithAssociations = product
-    loadAssociations(associations)
+    try {
+      const { loadAssociations, product } = useProduct(this.page.product)
+      this.productWithAssociations = product
+      await loadAssociations(associations)
+    } catch (e) {
+      console.error('ProductView:mounted:loadAssociations', e)
+    }
   }
 }
 </script>

--- a/packages/helpers/src/error/index.ts
+++ b/packages/helpers/src/error/index.ts
@@ -3,9 +3,7 @@ import { ShopwareError } from "@shopware-pwa/commons/interfaces/errors/ApiError"
 /**
  * Get the messages from the API response (array of ShopwareErrors)
  */
-export function getMessagesFromErrorsArray(
-  errors: ShopwareError[]
-): string[] {
+export function getMessagesFromErrorsArray(errors: ShopwareError[]): string[] {
   if (!errors?.length || !Array.isArray(errors)) {
     return [];
   }


### PR DESCRIPTION
prevents displaying error page for async calls which are rejected for some reason

## Changes
- composable useUser, getCustomer - affected
- default theme async calls on mounted


## Checklist

- [x] I followed code and contributing guidelines
- [x] I wrote all needed tests

## Keep in mind
- [ ] create issue for global error logger (abandon using console.log/error/info directly)
