### PR TITLE
chore(workflow): add check for PR title

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,21 @@
+name: Check PR title
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aslafy-z/conventional-pr-title-action@v2.2.0
+        with:
+          success-state: Title follows the conventional commits specifivation.
+          failure-state: Title does not follow the conventional commits specification.
+          context-name: conventional-pr-title
+          preset: conventional-changelog-angular@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,21 +2,21 @@
 
 ## How to start
 
-Before you start contributing, you should fork this repository and pick up the issue. 
+Before you start contributing, you should fork this repository and pick up the issue.
 
-**Issues, labeled with `core-team`, `shopware-task` are reserved for Shopware-PWA Core Team Members and Shopware Core Team**. 
+**Issues, labeled with `core-team`, `shopware-task` are reserved for Shopware-PWA Core Team Members and Shopware Core Team**.
 
 To find community tasks [click here](https://github.com/DivanteLtd/shopware-pwa/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+-label%3A%22Shopware+Task%22+-label%3A%22Core+Team%22+) or use following filter in the issues:
 
-``` 
-is:open is:issue -label:"Shopware Task" -label:"Core Team" 
+```
+is:open is:issue -label:"Shopware Task" -label:"Core Team"
 ```
 
 After choosing the task, you can solve the problem and create a pull request (PR). Feature requests should be discussed on our Slack channel (please see the link in [README.md](https://github.com/DivanteLtd/shopware-pwa)). After the discussion, please create the issue describing your request.
 
 **Github Project Broad is intended only for core developers.**
 
-**Please read the code of conduct and follow it in all your interactions with the project.** 
+**Please read the code of conduct and follow it in all your interactions with the project.**
 
 Thank you for your interest in, and engagement! :)
 
@@ -45,6 +45,11 @@ We keep 100% test coverage for our packages (except `default-theme`). Before ope
 
 There is a Pull Request template, that contributors should follow. To merge a branch into master two reviewers must accept the changes. All continuous integration checks must pass. Note that, only Shopware-PWA Core Team Members are allowed to accept pull requests.
 
-If you face any problems during the implementation of the complex issue, feel free to implement just a part of it and ask for help in the comment. It's OK if you can only handle styling/tests/whatever. 
+To merge PR needs to meet the following conditions:
+
+- title follows conventional [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (ex. `feat(default-theme): super new functionality` or `fix(helpers): incorrect result for getProductName`). There is a PR check, which shows if the title meets this requirement.
+- fix or functionality is possibly the smallest as it can and should contain only changes in a single package.
+
+If you face any problems during the implementation of the complex issue, feel free to implement just a part of it and ask for help in the comment. It's OK if you can only handle styling/tests/whatever.
 
 In case of any problems feel free to contact us in comments or our Slack channel. :)


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
Added GH action check for PR title to follow Conventional Commmits.
First PR title should not pass to check this change and pass after that.


<!-- Paste here screenshot if there are visual changes -->



### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
