### PR TITLE
docs: new shopware version compatibility

### DIFF
--- a/packages/shopware-6-client/README.md
+++ b/packages/shopware-6-client/README.md
@@ -1,7 +1,7 @@
 # API client for Shopware 6
 
 Compatibility with Shopware 6:  
-[![shopware-ver](https://img.shields.io/badge/version-6.1.1-orange)](https://github.com/shopware/platform/releases/tag/v6.1.1)
+[![shopware-ver](https://img.shields.io/badge/version-6.1.4-orange)](https://github.com/shopware/platform/releases/tag/v6.1.4)
 
 ## Installing
 


### PR DESCRIPTION
sets v6.1.4 shopware version as a compatible. 



<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
