### PR TITLE
fix: add nuxt link to buffer SfProductOption

### DIFF
--- a/packages/default-theme/components/SwBottomNavigation.vue
+++ b/packages/default-theme/components/SwBottomNavigation.vue
@@ -13,10 +13,12 @@
               :key="route.routeLabel"
               :value="route"
             >
-              <SfProductOption
-                :value="route"
-                :label="route.routeLabel"
-              ></SfProductOption>
+              <nuxt-link class="sf-header__link" :to="route.routePath">
+                <SfProductOption
+                  :value="route"
+                  :label="route.routeLabel"
+                />
+              </nuxt-link>
             </SfSelectOption>
           </SfSelect>
         </template>


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

closes: #578 

Add nuxt-link to SfProductOption


<!-- Paste here screenshot if there are visual changes -->

![mobile menu works](https://user-images.githubusercontent.com/32803679/78330877-35af4300-7585-11ea-8734-7b99378e4c1e.gif)


### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
