### PR TITLE
fix: change the way of displaying product collection page switch

### DIFF
--- a/packages/default-theme/components/cms/elements/SwProductListingSlot.vue
+++ b/packages/default-theme/components/cms/elements/SwProductListingSlot.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="sw-product-list">
-    <SfLoader :loading="loading">
-      <div class="sw-product-list__wrapper" v-if="products.length && !loading">
-        <div class="sw-product-list__list">
+    <SfLoader :loading="loading" class="sw-product-list__loader">
+    </SfLoader>
+      <div class="sw-product-list__wrapper" v-if="products.length">
+        <div class="sw-product-list__list" :class="{'sw-product-list__list--blur': loading}">
           <SwProductCard
             class="sw-product-list__product-card"
             v-for="product in products"
@@ -24,7 +25,6 @@
         title="No products found"
         subtitle="let us look for them"
       />
-    </SfLoader>
   </div>
 </template>
 
@@ -132,6 +132,17 @@ $col-prod-1: 1 0 $mx-photo-wth-1;
 .sw-product-list {
   display: flex;
   justify-content: center;
+  position: relative;
+
+  &__loader {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    --loader-overlay-background: transparent;
+    width: 38px;
+    height: 38px;
+  }
 
   ::v-deep &__wrapper {
     display: flex;
@@ -143,6 +154,10 @@ $col-prod-1: 1 0 $mx-photo-wth-1;
     display: flex;
     width: 100%;
     flex-flow: row wrap;
+    transition: filter .1s ease-in;
+    &--blur {
+      filter: blur(10px);
+    }
   }
 
   ::v-deep &__product-card {
@@ -223,11 +238,5 @@ $col-prod-1: 1 0 $mx-photo-wth-1;
   @include for-desktop-big {
     max-width: $mx-photo-wth-5 !important;
   }
-}
-
-::v-deep .sf-loader {
-  width: 100%;
-  display: flex;
-  justify-content: center;
 }
 </style>

--- a/packages/default-theme/components/cms/elements/SwProductListingSlot.vue
+++ b/packages/default-theme/components/cms/elements/SwProductListingSlot.vue
@@ -141,6 +141,7 @@ $col-prod-1: 1 0 $mx-photo-wth-1;
     --loader-overlay-background: transparent;
     width: 38px;
     height: 38px;
+    z-index: 2;
   }
 
   ::v-deep &__wrapper {

--- a/packages/default-theme/components/cms/elements/SwProductListingSlot.vue
+++ b/packages/default-theme/components/cms/elements/SwProductListingSlot.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="sw-product-list">
-    <SfLoader :loading="loading" class="sw-product-list__loader">
-    </SfLoader>
+    <SfLoader :loading="loading" class="sw-product-list__loader"/>
       <div class="sw-product-list__wrapper" v-if="products.length">
         <div class="sw-product-list__list" :class="{'sw-product-list__list--blur': loading}">
           <SwProductCard


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes: #380 

When product collection page is switched there is bllured filter now at product list.

<!-- Paste here screenshot if there are visual changes -->
Before:
![category before](https://user-images.githubusercontent.com/32803679/78531017-f97a1d80-77e4-11ea-9aac-433385794330.gif)
After:
![category after](https://user-images.githubusercontent.com/32803679/78531029-fda63b00-77e4-11ea-9cab-f86cf9f4042f.gif)


### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
