### PR TITLE
fix: set product listing to 100% width

### DIFF
--- a/packages/default-theme/cms/elements/CmsElementProductListing.vue
+++ b/packages/default-theme/cms/elements/CmsElementProductListing.vue
@@ -134,6 +134,7 @@ $col-prod-1: 1 0 $mx-photo-wth-1;
   display: flex;
   justify-content: center;
   position: relative;
+  width: 100%;
 
   &__loader {
     position: absolute;


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #654 

cms-element-product-listing class is now set to 100% width;






<!-- Paste here screenshot if there are visual changes -->
Before: 
![image](https://user-images.githubusercontent.com/32803679/80939276-67ae0200-8ddc-11ea-8ebc-cf939d666976.png)
After:
![image](https://user-images.githubusercontent.com/32803679/80939292-798fa500-8ddc-11ea-8c14-fa4108ba5ff1.png)






### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
