### PR TITLE
fix: color select filter is possible to click

### DIFF
--- a/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
+++ b/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
@@ -74,7 +74,7 @@
                 "
                 class="filters__item"
                 :class="{'filters__item--color': option.color}"
-                @change.native="
+                @change="
                   toggleFilter({
                     type: 'equals',
                     value: option.value,
@@ -208,6 +208,9 @@ export default {
     getSortLabel(sorting) {
       return getSortingLabel(sorting)
     },
+    siema() {
+      console.log('siema');
+    }
   },
 }
 </script>

--- a/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
+++ b/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
@@ -207,9 +207,6 @@ export default {
     },
     getSortLabel(sorting) {
       return getSortingLabel(sorting)
-    },
-    siema() {
-      console.log('siema');
     }
   },
 }


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #689 

It's possible to click color filter now

<!-- Paste here screenshot if there are visual changes -->

![filtersworks](https://user-images.githubusercontent.com/32803679/80943538-b6ad6480-8de7-11ea-944a-2feccbede93c.gif)


### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
