### PR TITLE
Copy-templates npm script fix

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "lint": "tslint -p . --fix",
     "clean-build": "rm -rf ./build",
     "compile": "tsc -p .",
-    "copy-templates": "if [ -e ./src/templates ]; then cp -a ./src/templates ./build/; fi",
+    "copy-templates": "cp -a ./src/templates ./build/",
     "build": "yarn format && yarn lint && yarn clean-build && yarn compile && yarn copy-templates",
     "test": "jest",
     "watch": "jest --watch",


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

`copy-templates` npm script fix , because it was an error as below

![image](https://user-images.githubusercontent.com/32803679/81695268-b1dd5600-9462-11ea-9cb0-2c31202ae509.png)



<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
