### PR TITLE
fix: add CmsBlockDefault for slider and text

### DIFF
--- a/packages/default-theme/cms/cmsMap.json
+++ b/packages/default-theme/cms/cmsMap.json
@@ -19,7 +19,9 @@
     "image-text-cover": "CmsBlockImageTextCover",
     "image-three-column": "CmsBlockImageThreeColumn",
     "image-three-cover": "CmsBlockImageThreeCover",
-    "image-two-column": "CmsBlockImageTwoColumn"
+    "image-two-column": "CmsBlockImageTwoColumn",
+    "product-slider": "CmsBlockDefault",
+    "text": "CmsBlockDefault"
   },
   "elements": {
     "product-box": "CmsElementProductCard",


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
`CmsBlockDefault` added for `text` and `product-slider` blocks



<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
