### PR TITLE
feat(default-theme): parse html tags in product description

### DIFF
--- a/packages/default-theme/components/SwProductDetails.vue
+++ b/packages/default-theme/components/SwProductDetails.vue
@@ -11,9 +11,7 @@
       />
     </div>
     <SwPluginSlot name="product-page-description">
-      <p class="product-details__description desktop-only">
-        {{ description }}
-      </p>
+      <p class="product-details__description desktop-only" v-html="description"/>
     </SwPluginSlot>
     <!-- <div class="product-details__action">
       <button v-if="sizes.length > 0" class="sf-action">Size guide</button>

--- a/packages/default-theme/components/SwProductTabs.vue
+++ b/packages/default-theme/components/SwProductTabs.vue
@@ -4,9 +4,7 @@
       <slot>
         <SfTab title="Description">
           <div>
-            <p>
-              {{ description }}
-            </p>
+            <p v-html="description" />
           </div>
         </SfTab>
         <SfTab title="Properties">


### PR DESCRIPTION
## Changes
allows description to be parsed as html


### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
