### PR TITLE
Feat/store api for context related areas #551

### DIFF
--- a/api/shopware-6-client.api.md
+++ b/api/shopware-6-client.api.md
@@ -129,19 +129,19 @@ export function deleteCustomerAddress(addressId: string): Promise<void>;
 export function getAvailableCountries(): Promise<SearchResult<Country[]>>;
 
 // @alpha (undocumented)
-export function getAvailableCurrencies(): Promise<SearchResult<Currency[]>>;
+export function getAvailableCurrencies(): Promise<Currency[]>;
 
 // @alpha (undocumented)
 export function getAvailableLanguages(): Promise<SearchResult<Language[]>>;
 
 // @alpha (undocumented)
-export function getAvailablePaymentMethods(): Promise<SearchResult<PaymentMethod[]>>;
+export function getAvailablePaymentMethods(): Promise<PaymentMethod[]>;
 
 // @alpha
 export function getAvailableSalutations(): Promise<SearchResult<Salutation[]>>;
 
 // @alpha (undocumented)
-export function getAvailableShippingMethods(): Promise<SearchResult<ShippingMethod[]>>;
+export function getAvailableShippingMethods(): Promise<ShippingMethod[]>;
 
 // @alpha
 export function getCart(): Promise<Cart>;

--- a/packages/composables/__tests__/useCheckout.spec.ts
+++ b/packages/composables/__tests__/useCheckout.spec.ts
@@ -185,15 +185,12 @@ describe("Composables - useCheckout", () => {
         await getShippingMethods({ forceReload: true });
       });
       it("should return Shipping methods from API", async () => {
-        mockedApiClient.getAvailableShippingMethods.mockResolvedValueOnce({
-          total: 2,
-          data: [
-            {
-              name: "Shipping method 1",
-            },
-            { name: "Shipping method 2" },
-          ],
-        } as any);
+        mockedApiClient.getAvailableShippingMethods.mockResolvedValueOnce([
+          {
+            name: "Shipping method 1",
+          },
+          { name: "Shipping method 2" },
+        ] as any);
         const { getShippingMethods } = useCheckout();
         const result = await getShippingMethods();
         expect(result.value).toEqual([
@@ -203,9 +200,9 @@ describe("Composables - useCheckout", () => {
       });
 
       it("should return an empty array if response data is not defined", async () => {
-        mockedApiClient.getAvailableShippingMethods.mockResolvedValueOnce({
-          total: 2,
-        } as any);
+        mockedApiClient.getAvailableShippingMethods.mockResolvedValueOnce(
+          [] as any
+        );
         const { getShippingMethods } = useCheckout();
         const result = await getShippingMethods();
         expect(result.value).toEqual([]);
@@ -222,15 +219,12 @@ describe("Composables - useCheckout", () => {
       });
 
       it("should not call api if Shipping methods are already in cache", async () => {
-        mockedApiClient.getAvailableShippingMethods.mockResolvedValueOnce({
-          total: 2,
-          data: [
-            {
-              name: "Shipping method 1",
-            },
-            { name: "Shipping method 2" },
-          ],
-        } as any);
+        mockedApiClient.getAvailableShippingMethods.mockResolvedValueOnce([
+          {
+            name: "Shipping method 1",
+          },
+          { name: "Shipping method 2" },
+        ] as any);
         const { getShippingMethods } = useCheckout();
 
         const result = await getShippingMethods();
@@ -246,6 +240,14 @@ describe("Composables - useCheckout", () => {
 
         expect(mockedApiClient.getAvailableShippingMethods).toBeCalledTimes(1);
       });
+      it("should return an empty array if response data is not defined", async () => {
+        mockedApiClient.getAvailableShippingMethods.mockResolvedValueOnce(
+          undefined as any
+        );
+        const { getShippingMethods } = useCheckout();
+        const result = await getShippingMethods();
+        expect(result.value).toEqual([]);
+      });
     });
 
     describe("getPaymentMethods", () => {
@@ -258,15 +260,12 @@ describe("Composables - useCheckout", () => {
         await getPaymentMethods({ forceReload: true });
       });
       it("should return Payment methods from API", async () => {
-        mockedApiClient.getAvailablePaymentMethods.mockResolvedValueOnce({
-          total: 2,
-          data: [
-            {
-              name: "Payment method 1",
-            },
-            { name: "Payment method 2" },
-          ],
-        } as any);
+        mockedApiClient.getAvailablePaymentMethods.mockResolvedValueOnce([
+          {
+            name: "Payment method 1",
+          },
+          { name: "Payment method 2" },
+        ] as any);
         const { getPaymentMethods } = useCheckout();
         const result = await getPaymentMethods();
         expect(result.value).toEqual([
@@ -276,9 +275,18 @@ describe("Composables - useCheckout", () => {
       });
 
       it("should return an empty array if response data is not defined", async () => {
-        mockedApiClient.getAvailablePaymentMethods.mockResolvedValueOnce({
-          total: 2,
-        } as any);
+        mockedApiClient.getAvailablePaymentMethods.mockResolvedValueOnce(
+          [] as any
+        );
+        const { getPaymentMethods } = useCheckout();
+        const result = await getPaymentMethods();
+        expect(result.value).toEqual([]);
+      });
+
+      it("should return an empty array if response data is not defined", async () => {
+        mockedApiClient.getAvailablePaymentMethods.mockResolvedValueOnce(
+          undefined as any
+        );
         const { getPaymentMethods } = useCheckout();
         const result = await getPaymentMethods();
         expect(result.value).toEqual([]);
@@ -295,15 +303,12 @@ describe("Composables - useCheckout", () => {
       });
 
       it("should not call api if Payment methods are already in cache", async () => {
-        mockedApiClient.getAvailablePaymentMethods.mockResolvedValueOnce({
-          total: 2,
-          data: [
-            {
-              name: "Payment method 1",
-            },
-            { name: "Payment method 2" },
-          ],
-        } as any);
+        mockedApiClient.getAvailablePaymentMethods.mockResolvedValueOnce([
+          {
+            name: "Payment method 1",
+          },
+          { name: "Payment method 2" },
+        ] as any);
         const { getPaymentMethods } = useCheckout();
 
         const result = await getPaymentMethods();

--- a/packages/composables/__tests__/useCheckout.spec.ts
+++ b/packages/composables/__tests__/useCheckout.spec.ts
@@ -199,7 +199,7 @@ describe("Composables - useCheckout", () => {
         ]);
       });
 
-      it("should return an empty array if response data is not defined", async () => {
+      it("should return an empty array if response data is an empty array", async () => {
         mockedApiClient.getAvailableShippingMethods.mockResolvedValueOnce(
           [] as any
         );
@@ -274,7 +274,7 @@ describe("Composables - useCheckout", () => {
         ]);
       });
 
-      it("should return an empty array if response data is not defined", async () => {
+      it("should return an empty array if response data is an empty array", async () => {
         mockedApiClient.getAvailablePaymentMethods.mockResolvedValueOnce(
           [] as any
         );

--- a/packages/composables/__tests__/useProductListing.spec.ts
+++ b/packages/composables/__tests__/useProductListing.spec.ts
@@ -212,7 +212,7 @@ describe("Composables - useProductListing", () => {
 
     it("should not change pagination state to privided one once a useProductListing argument is passed hasn't any required fields", async () => {
       const { pagination } = useProductListing({
-        page: undefined
+        page: undefined,
       } as any);
 
       expect(pagination.value).toStrictEqual({

--- a/packages/composables/src/logic/useCheckout.ts
+++ b/packages/composables/src/logic/useCheckout.ts
@@ -68,7 +68,7 @@ export const useCheckout = (): UseCheckout => {
   ) => {
     if (shippingMethods.value.length && !forceReload) return shippingMethods;
     const shippingMethodsResponse = await getAvailableShippingMethods();
-    orderData.shippingMethods = shippingMethodsResponse.data || [];
+    orderData.shippingMethods = shippingMethodsResponse || [];
     return shippingMethods;
   };
 
@@ -77,7 +77,7 @@ export const useCheckout = (): UseCheckout => {
   ) => {
     if (paymentMethods.value.length && !forceReload) return paymentMethods;
     const paymentMethodsResponse = await getAvailablePaymentMethods();
-    orderData.paymentMethods = paymentMethodsResponse.data || [];
+    orderData.paymentMethods = paymentMethodsResponse || [];
     return paymentMethods;
   };
 

--- a/packages/shopware-6-client/__tests__/endpoints.spec.ts
+++ b/packages/shopware-6-client/__tests__/endpoints.spec.ts
@@ -230,14 +230,14 @@ describe("endpoints", () => {
   describe("getContextCurrencyEndpoint", () => {
     it("should return Shopware currency endpoint", async () => {
       const result = getContextCurrencyEndpoint();
-      expect(result).toEqual("/sales-channel-api/v1/currency");
+      expect(result).toEqual("/store-api/v1/currency");
     });
   });
 
   describe("getContextLanguageEndpoint", () => {
     it("should return Shopware language endpoint", async () => {
       const result = getContextLanguageEndpoint();
-      expect(result).toEqual("/sales-channel-api/v1/language");
+      expect(result).toEqual("/store-api/v1/language");
     });
   });
 
@@ -251,13 +251,13 @@ describe("endpoints", () => {
   describe("getContextPaymentMethodEndpoint", () => {
     it("should return Shopware payment method endpoint", async () => {
       const result = getContextPaymentMethodEndpoint();
-      expect(result).toEqual("/sales-channel-api/v1/payment-method");
+      expect(result).toEqual("/store-api/v1/payment-method");
     });
   });
   describe("getContextShippingMethodEndpoint", () => {
     it("should return Shopware shipping method endpoint", async () => {
       const result = getContextShippingMethodEndpoint();
-      expect(result).toEqual("/sales-channel-api/v1/shipping-method");
+      expect(result).toEqual("/store-api/v1/shipping-method");
     });
   });
 

--- a/packages/shopware-6-client/__tests__/services/ContextService/getAvailableCurrencies.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/getAvailableCurrencies.spec.ts
@@ -9,10 +9,10 @@ describe("ContextService - getAvailableCurrencies", () => {
     jest.resetAllMocks();
   });
   it("should return array with currencies", async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: { data: [{ iso: "EUR" }] } });
+    mockedAxios.get.mockResolvedValueOnce({ data: [{ iso: "EUR" }] });
     const result = await getAvailableCurrencies();
     expect(mockedAxios.get).toBeCalledTimes(1);
-    expect(mockedAxios.get).toBeCalledWith("/sales-channel-api/v1/currency");
+    expect(mockedAxios.get).toBeCalledWith("/store-api/v1/currency");
     expect(result).toEqual([{ iso: "EUR" }]);
   });
 });

--- a/packages/shopware-6-client/__tests__/services/ContextService/getAvailableLanguages.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/getAvailableLanguages.spec.ts
@@ -13,7 +13,7 @@ describe("ContextService - getAvailableLanguages", () => {
 
     const result = await getAvailableLanguages();
     expect(mockedAxios.get).toBeCalledTimes(1);
-    expect(mockedAxios.get).toBeCalledWith("/sales-channel-api/v1/language");
+    expect(mockedAxios.get).toBeCalledWith("/store-api/v1/language");
     expect(result.total).toEqual(2);
   });
 });

--- a/packages/shopware-6-client/__tests__/services/ContextService/getAvailablePaymentMethods.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/getAvailablePaymentMethods.spec.ts
@@ -9,13 +9,11 @@ describe("ContextService - getAvailablePaymentMethods", () => {
     jest.resetAllMocks();
   });
   it("should return array with payment methods", async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: { total: 2 } });
+    mockedAxios.get.mockResolvedValueOnce({ data: [{ id: 1 }, { id: 2 }] });
 
     const result = await getAvailablePaymentMethods();
     expect(mockedAxios.get).toBeCalledTimes(1);
-    expect(mockedAxios.get).toBeCalledWith(
-      "/sales-channel-api/v1/payment-method"
-    );
-    expect(result.total).toEqual(2);
+    expect(mockedAxios.get).toBeCalledWith("/store-api/v1/payment-method");
+    expect(result).toHaveLength(2);
   });
 });

--- a/packages/shopware-6-client/__tests__/services/ContextService/getAvailableShippingMethods.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/getAvailableShippingMethods.spec.ts
@@ -9,13 +9,11 @@ describe("ContextService - getAvailableShippingMethods", () => {
     jest.resetAllMocks();
   });
   it("should return array with shipping methods", async () => {
-    mockedAxios.get.mockResolvedValueOnce({ data: { total: 2 } });
+    mockedAxios.get.mockResolvedValueOnce({ data: [{ id: 1 }, { id: 2 }] });
 
     const result = await getAvailableShippingMethods();
     expect(mockedAxios.get).toBeCalledTimes(1);
-    expect(mockedAxios.get).toBeCalledWith(
-      "/sales-channel-api/v1/shipping-method"
-    );
-    expect(result.total).toEqual(2);
+    expect(mockedAxios.get).toBeCalledWith("/store-api/v1/shipping-method");
+    expect(result).toHaveLength(2);
   });
 });

--- a/packages/shopware-6-client/__tests__/services/ContextService/getSessionContext.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/getSessionContext.spec.ts
@@ -14,7 +14,7 @@ describe("ContextService - getSessionContext", () => {
 
     const result: SessionContext = await getSessionContext();
     expect(mockedAxios.get).toBeCalledTimes(1);
-    expect(mockedAxios.get).toBeCalledWith("/sales-channel-api/v1/context");
+    expect(mockedAxios.get).toBeCalledWith("/store-api/v1/context");
     expect(result.token).toEqual("qwerty");
   });
 });

--- a/packages/shopware-6-client/__tests__/services/ContextService/setCurrentBillingAddress.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/setCurrentBillingAddress.spec.ts
@@ -23,7 +23,7 @@ describe("ContextService - setCurrentBillingAddress with contextToken given", ()
     const result = await setCurrentBillingAddress(newBillingAddressId);
 
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       billingAddressId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 
@@ -46,7 +46,7 @@ describe("ContextService - setCurrentBillingAddress without contextToken given",
 
     const result = await setCurrentBillingAddress(newBillingAddressId);
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       billingAddressId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 

--- a/packages/shopware-6-client/__tests__/services/ContextService/setCurrentCurrency.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/setCurrentCurrency.spec.ts
@@ -24,7 +24,7 @@ describe("ContextService - setCurrentCurrency with contextToken given", () => {
     const result = await setCurrentCurrency(newCurrencyId);
 
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       currencyId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 
@@ -49,7 +49,7 @@ describe("ContextService - setCurrentCurrency without contextToken given", () =>
     const result = await setCurrentCurrency(newCurrencyId);
 
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       currencyId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 

--- a/packages/shopware-6-client/__tests__/services/ContextService/setCurrentLanguage.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/setCurrentLanguage.spec.ts
@@ -20,7 +20,7 @@ describe("ContextService - setCurrentLanguage with contextToken given", () => {
     const result = await setCurrentLanguage(newLanguageId);
 
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       languageId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 
@@ -44,7 +44,7 @@ describe("ContextService - setCurrentLanguage without contextToken given", () =>
     const result = await setCurrentLanguage(newLanguageId);
 
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       languageId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 

--- a/packages/shopware-6-client/__tests__/services/ContextService/setCurrentPaymentMethod.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/setCurrentPaymentMethod.spec.ts
@@ -23,7 +23,7 @@ describe("ContextService - setCurrentPaymentMethod with contextToken given", () 
     const result = await setCurrentPaymentMethod(newPaymentMethodId);
 
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       paymentMethodId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 
@@ -47,7 +47,7 @@ describe("ContextService - setCurrentPaymentMethod without contextToken given", 
     const result = await setCurrentPaymentMethod(newPaymentMethodId);
 
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       paymentMethodId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 

--- a/packages/shopware-6-client/__tests__/services/ContextService/setCurrentShippingAddress.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/setCurrentShippingAddress.spec.ts
@@ -23,7 +23,7 @@ describe("ContextService - setCurrentShippingAddress with contextToken given", (
     const result = await setCurrentShippingAddress(newShippingAddressId);
 
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       shippingAddressId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 
@@ -46,7 +46,7 @@ describe("ContextService - setCurrentShippingAddress without contextToken given"
 
     const result = await setCurrentShippingAddress(newShippingAddressId);
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       shippingAddressId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 

--- a/packages/shopware-6-client/__tests__/services/ContextService/setCurrentShippingMethod.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/ContextService/setCurrentShippingMethod.spec.ts
@@ -23,7 +23,7 @@ describe("ContextService - setCurrentShippingMethod with contextToken given", ()
     const result = await setCurrentShippingMethod(newShippingMethodId);
 
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       shippingMethodId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 
@@ -47,7 +47,7 @@ describe("ContextService - setCurrentShippingMethod without contextToken given",
     const result = await setCurrentShippingMethod(newShippingMethodId);
 
     expect(mockedAxios.patch).toBeCalledTimes(1);
-    expect(mockedAxios.patch).toBeCalledWith("/sales-channel-api/v1/context", {
+    expect(mockedAxios.patch).toBeCalledWith("/store-api/v1/context", {
       shippingMethodId: "45f96f681f9d4834b29e9e15df3a7149",
     });
 

--- a/packages/shopware-6-client/src/endpoints.ts
+++ b/packages/shopware-6-client/src/endpoints.ts
@@ -98,13 +98,11 @@ export const getCheckoutPromotionCodeEndpoint = (code: string) =>
 
 // context
 
-export const getContextEndpoint = () => `/sales-channel-api/v1/context`;
+export const getContextEndpoint = () => `/store-api/v1/context`;
 
-export const getContextCurrencyEndpoint = () =>
-  `/sales-channel-api/v1/currency`;
+export const getContextCurrencyEndpoint = () => `/store-api/v1/currency`;
 
-export const getContextLanguageEndpoint = () =>
-  `/sales-channel-api/v1/language`;
+export const getContextLanguageEndpoint = () => `/store-api/v1/language`;
 
 export const getContextCountryEndpoint = () => `/sales-channel-api/v1/country`;
 
@@ -112,10 +110,10 @@ export const getContextCountryItemEndpoint = (countryId: string): string =>
   `/sales-channel-api/v1/country/${countryId}`;
 
 export const getContextPaymentMethodEndpoint = () =>
-  `/sales-channel-api/v1/payment-method`;
+  `/store-api/v1/payment-method`;
 
 export const getContextShippingMethodEndpoint = () =>
-  `/sales-channel-api/v1/shipping-method`;
+  `/store-api/v1/shipping-method`;
 
 export const getContextSalutationEndpoint = () => `/store-api/v1/salutation`;
 

--- a/packages/shopware-6-client/src/services/contextService.ts
+++ b/packages/shopware-6-client/src/services/contextService.ts
@@ -73,12 +73,10 @@ export function setCurrentBillingAddress(
  * @throws ClientApiError
  * @alpha
  */
-export async function getAvailableCurrencies(): Promise<
-  SearchResult<Currency[]>
-> {
+export async function getAvailableCurrencies(): Promise<Currency[]> {
   const resp = await apiService.get(getContextCurrencyEndpoint());
 
-  return resp.data.data;
+  return resp.data;
 }
 
 /**
@@ -149,9 +147,7 @@ export async function getAvailableSalutations(): Promise<
  * @throws ClientApiError
  * @alpha
  */
-export async function getAvailablePaymentMethods(): Promise<
-  SearchResult<PaymentMethod[]>
-> {
+export async function getAvailablePaymentMethods(): Promise<PaymentMethod[]> {
   const resp = await apiService.get(getContextPaymentMethodEndpoint());
 
   return resp.data;
@@ -174,9 +170,7 @@ export async function setCurrentPaymentMethod(
  * @throws ClientApiError
  * @alpha
  */
-export async function getAvailableShippingMethods(): Promise<
-  SearchResult<ShippingMethod[]>
-> {
+export async function getAvailableShippingMethods(): Promise<ShippingMethod[]> {
   const resp = await apiService.get(getContextShippingMethodEndpoint());
 
   return resp.data;


### PR DESCRIPTION
## Changes
closes #551 
- replaces sales-channel-api with store-api if possible
- adjusts parsing the payload for the corresponding endpoints




<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
