### PR TITLE
fix(a11y): show outline

### DIFF
--- a/packages/default-theme/layouts/default.vue
+++ b/packages/default-theme/layouts/default.vue
@@ -175,12 +175,4 @@ body {
 .sw-breadcrumbs {
   padding: 0 var(--spacer-xl) var(--spacer-base) var(--spacer-xl);
 }
-
-/* Delete firefox outline */
-:focus {
-  outline: none;
-}
-::-moz-focus-inner {
-  border: 0;
-}
 </style>


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
we should show outline always when user use tab to the navigation
<!-- Paste here screenshot if there are visual changes -->
<img width="396" alt="Zrzut ekranu 2020-05-20 o 10 13 42" src="https://user-images.githubusercontent.com/12138170/82422350-9ede0d80-9a82-11ea-93e8-98afda9b3c32.png">
### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
