### PR TITLE
feat: styling currency and language switchers

### DIFF
--- a/packages/default-theme/components/SwLanguageSwitcher.vue
+++ b/packages/default-theme/components/SwLanguageSwitcher.vue
@@ -2,9 +2,9 @@
   <div class="sw-language-switcher">
     <SfSelect
       :selected="currentLocale"
-      @change="changeLocale"
       :size="availableLanguages.length"
-      class="sw-language-switcher__select"
+      class="sw-language-switcher__select sf-select--no-chevron"
+      @change="changeLocale"
     >
       <SfSelectOption
         v-for="language in availableLanguages"
@@ -41,13 +41,11 @@ export default {
 @import '~@storefront-ui/vue/styles';
 
 .sw-language-switcher {
+  --select-padding: 0;
+  --select-margin: 0;
+  --select-selected-padding: 0 var(--spacer-xs);
+  --select-selected-justify-content: center;
   text-align: center;
-  &__select {
-    --select-margin: 0;
-    --chevron-size: 0;
-    --select-option-font-size: var(--font-base);
-    --select-selected-padding: 0.5rem;
-    cursor: pointer;
-  }
+  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #759
### Acceptance criteria
- [x] better styling elements
- [x] closes after clicking outside
- [ ] remove blocking TODOs inside currency switcher (https://github.com/DivanteLtd/storefront-ui/issues/1097) <- not resolved

the content inside selected el will be center after next storefront-ui release because after that we gen new css variable to fix this case https://github.com/DivanteLtd/storefront-ui/commit/e6c7d1621dd179233556e2d623496a6ab66ef266
<!-- Paste here screenshot if there are visual changes -->
Language Selector
![Zrzut ekranu 2020-05-22 o 11 11 47](https://user-images.githubusercontent.com/12138170/82653921-3af14b80-9c20-11ea-980e-13ff9dfab598.png)
Currency selector
![Zrzut ekranu 2020-05-22 o 12 54 07](https://user-images.githubusercontent.com/12138170/82660921-59107900-9c2b-11ea-9248-d65ae3241e71.png)




### Checklist

- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
