### PR TITLE
feat(cli): generate CMS and plugins folder to easily develop them locally

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -116,8 +116,10 @@ module.exports = {
     generateFilesSpinner.succeed();
 
     // generate plugin files
+    await toolbox.createPluginsTemplate()
     await toolbox.runtime.run(`plugins`, inputParameters);
     await toolbox.runtime.run(`cms`);
+    await toolbox.createCmsTemplate(); // generate template for user CMS folder
     await toolbox.runtime.run(`languages`, inputParameters);
 
     const updateDependenciesSpinner = spin("Updating dependencies");

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -108,6 +108,8 @@ module.exports = {
       },
     });
 
+    await toolbox.runtime.run(`languages`, inputParameters);
+
     success(`Plugins generated`);
   },
 };

--- a/packages/cli/src/extensions/cms-extensions.ts
+++ b/packages/cli/src/extensions/cms-extensions.ts
@@ -30,4 +30,34 @@ module.exports = (toolbox: GluegunToolbox) => {
 
     merge(cmsComponentsMap, readedMap);
   };
+
+  toolbox.createCmsTemplate = async (directoryPath = "cms") => {
+    const cmsMapFileName = "cmsMap.json";
+    const cmsReadmeFile = "readme.md";
+    // create folders structure
+    await toolbox.filesystem.dirAsync(directoryPath);
+    await toolbox.filesystem.dirAsync(join(directoryPath, "sections"));
+    await toolbox.filesystem.dirAsync(join(directoryPath, "blocks"));
+    await toolbox.filesystem.dirAsync(join(directoryPath, "elements"));
+    const cmsMapConfigExists = await toolbox.filesystem.existsAsync(
+      join(directoryPath, cmsMapFileName)
+    );
+    if (!cmsMapConfigExists) {
+      await toolbox.template.generate({
+        template: "/cms/" + cmsMapFileName,
+        target: "cms/" + cmsMapFileName,
+        props: {},
+      });
+    }
+    const cmsReadmeExists = await toolbox.filesystem.existsAsync(
+      join(directoryPath, cmsReadmeFile)
+    );
+    if (!cmsReadmeExists) {
+      await toolbox.template.generate({
+        template: "/cms/" + cmsReadmeFile,
+        target: "cms/" + cmsReadmeFile,
+        props: {},
+      });
+    }
+  };
 };

--- a/packages/cli/src/extensions/nuxt-extension.ts
+++ b/packages/cli/src/extensions/nuxt-extension.ts
@@ -72,15 +72,6 @@ module.exports = (toolbox: GluegunToolbox) => {
     await toolbox.patching.update("package.json", (config) => {
       config.scripts.lint = "prettier --write '*.{js,vue}'";
 
-      config["lint-staged"] = {
-        "*.{js,vue}": "prettier",
-      };
-      config["husky"] = {
-        hooks: {
-          "pre-commit": "lint-staged",
-        },
-      };
-
       // update versions to canary
       if (canary) {
         Object.keys(config.dependencies).forEach((dependencyName) => {

--- a/packages/cli/src/extensions/nuxt-extension.ts
+++ b/packages/cli/src/extensions/nuxt-extension.ts
@@ -90,7 +90,7 @@ module.exports = (toolbox: GluegunToolbox) => {
         });
         Object.keys(config.devDependencies).forEach((dependencyName) => {
           if (dependencyName.includes("@shopware-pwa")) {
-            config.dependencies[dependencyName] = "canary";
+            config.devDependencies[dependencyName] = "canary";
           }
         });
       }

--- a/packages/cli/src/extensions/plugins-extensions.ts
+++ b/packages/cli/src/extensions/plugins-extensions.ts
@@ -1,5 +1,6 @@
 import { GluegunToolbox } from "gluegun";
 import axios from "axios";
+import { join } from "path";
 
 module.exports = (toolbox: GluegunToolbox) => {
   toolbox.fetchPluginsAuthToken = async (
@@ -217,6 +218,59 @@ module.exports = (toolbox: GluegunToolbox) => {
         console.error("UNEXPECTED ERROR", e ? e.response : e);
       }
       return;
+    }
+  };
+
+  toolbox.createPluginsTemplate = async () => {
+    const localPluginsDirName = "sw-plugins";
+    const localPluginsConfigFilename = "local-plugins.json";
+
+    const examplePluginDirectoryPath = join(
+      localPluginsDirName,
+      "my-local-plugin"
+    );
+    // create folders structure
+    await toolbox.filesystem.dirAsync(localPluginsDirName);
+    await toolbox.filesystem.dirAsync(examplePluginDirectoryPath);
+    const localPluginsConfigExists = await toolbox.filesystem.existsAsync(
+      join(localPluginsDirName, localPluginsConfigFilename)
+    );
+    if (!localPluginsConfigExists) {
+      await toolbox.template.generate({
+        template: "/plugins/" + localPluginsConfigFilename,
+        target: "sw-plugins/" + localPluginsConfigFilename,
+        props: {},
+      });
+    }
+    const localPluginConfigExists = await toolbox.filesystem.existsAsync(
+      join(examplePluginDirectoryPath, "config.json")
+    );
+    if (!localPluginConfigExists) {
+      await toolbox.template.generate({
+        template: "/plugins/my-local-plugin/config.json",
+        target: "sw-plugins/my-local-plugin/config.json",
+        props: {},
+      });
+    }
+    const localPluginVueFileExists = await toolbox.filesystem.existsAsync(
+      join(examplePluginDirectoryPath, "myLocalPlugin.vue")
+    );
+    if (!localPluginVueFileExists) {
+      await toolbox.template.generate({
+        template: "/plugins/my-local-plugin/myLocalPlugin.vue",
+        target: "sw-plugins/my-local-plugin/myLocalPlugin.vue",
+        props: {},
+      });
+    }
+    const cmsReadmeExists = await toolbox.filesystem.existsAsync(
+      join(localPluginsDirName, "readme.md")
+    );
+    if (!cmsReadmeExists) {
+      await toolbox.template.generate({
+        template: "/plugins/readme.md",
+        target: "sw-plugins/readme.md",
+        props: {},
+      });
     }
   };
 };

--- a/packages/cli/src/templates/cms/cmsMap.json
+++ b/packages/cli/src/templates/cms/cmsMap.json
@@ -1,0 +1,8 @@
+{
+  "sections": {
+  },
+  "blocks": {
+  },
+  "elements": {
+  }
+}

--- a/packages/cli/src/templates/cms/readme.md
+++ b/packages/cli/src/templates/cms/readme.md
@@ -1,0 +1,5 @@
+## Shopware PWA CMS
+
+In this directory you may override all CMS components from your theme and plugins.
+
+For instructions about CMS structure and how to override specific elements please visit https://shopware-pwa-docs.vuestorefront.io/guide/cms.html

--- a/packages/cli/src/templates/plugins/local-plugins.json
+++ b/packages/cli/src/templates/plugins/local-plugins.json
@@ -1,0 +1,3 @@
+{
+  "my-local-plugin": false
+}

--- a/packages/cli/src/templates/plugins/my-local-plugin/config.json
+++ b/packages/cli/src/templates/plugins/my-local-plugin/config.json
@@ -1,0 +1,9 @@
+{
+  "slots": [
+    {
+      "name": "top-header-after",
+      "file": "myLocalPlugin.vue"
+    }
+  ],
+  "settings": {}
+}

--- a/packages/cli/src/templates/plugins/my-local-plugin/myLocalPlugin.vue
+++ b/packages/cli/src/templates/plugins/my-local-plugin/myLocalPlugin.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="my-local-plugin">
+    <h3>Hello from your local plugin!</h3>
+  </div>
+</template>
+<script>
+export default {
+  name: "MyLocalPlugin",
+  data() {
+    return {};
+  },
+};
+</script>
+<style lang="scss" scoped>
+.my-local-plugin {
+  display: flex;
+  justify-content: center;
+  border: 1px solid green;
+}
+</style>

--- a/packages/cli/src/templates/plugins/readme.md
+++ b/packages/cli/src/templates/plugins/readme.md
@@ -1,0 +1,7 @@
+## Shopware PWA local plugins
+
+In this directory you may develop your Shopware PWA plugins locally.
+
+You'll find here config file with example of local plugin. Just switch flag in `local-plugins.json` to see local plugin in your application.
+
+For instructions about plugins structure and how to develop them please visit https://shopware-pwa-docs.vuestorefront.io/guide/plugins.html


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

closes #696, closes #648 

* creates cms directory with cmsMap.json file, cms component folders and readme.md with link to docs
* creates sw-plugin directory with an example plugin (turned off by default) displaying hello world + readme with link to docs


<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
