### PR TITLE
feat(default-theme): ability to override global styles and scss variables in single place 🎨 

### DIFF
--- a/packages/cli/src/extensions/nuxt-extension.ts
+++ b/packages/cli/src/extensions/nuxt-extension.ts
@@ -125,6 +125,19 @@ module.exports = (toolbox: GluegunToolbox) => {
       });
     }
 
+    // Add global SCSS file to config
+    const isGlobalScssFileAdded = await toolbox.patching.exists(
+      "nuxt.config.js",
+      `~assets/scss/main.scss`
+    );
+    if (!isGlobalScssFileAdded) {
+      await toolbox.patching.patch("nuxt.config.js", {
+        insert: `
+    '~assets/scss/main.scss',`,
+        after: "css: [",
+      });
+    }
+
     // ignore .yalc
     const yalcIgnoreExist = await toolbox.patching.exists(
       ".gitignore",
@@ -166,6 +179,24 @@ module.exports = (toolbox: GluegunToolbox) => {
       await toolbox.template.generate({
         template: "Dockerfile",
         target: `Dockerfile`,
+        props: {},
+      });
+    }
+
+    const isMainScssFileCreated = exists("./assets/scss/main.scss");
+    if (!isMainScssFileCreated) {
+      await toolbox.template.generate({
+        template: "main.scss",
+        target: `./assets/scss/main.scss`,
+        props: {},
+      });
+    }
+
+    const isVariablesScssFileCreated = exists("./assets/scss/variables.scss");
+    if (!isVariablesScssFileCreated) {
+      await toolbox.template.generate({
+        template: "variables.scss",
+        target: `./assets/scss/variables.scss`,
         props: {},
       });
     }

--- a/packages/cli/src/templates/cms/cmsMap.json
+++ b/packages/cli/src/templates/cms/cmsMap.json
@@ -1,8 +1,5 @@
 {
-  "sections": {
-  },
-  "blocks": {
-  },
-  "elements": {
-  }
+  "sections": {},
+  "blocks": {},
+  "elements": {}
 }

--- a/packages/cli/src/templates/main.scss
+++ b/packages/cli/src/templates/main.scss
@@ -1,0 +1,15 @@
+// we're importing here main style variables from theme
+@import '~@shopware-pwa/default-theme/assets/scss/main';
+
+// Here you can override you global styles.
+// It will be included once on webside and visible unless some more specific styles in components will extend that
+//
+// note: To override global variables go to variables.scss
+
+// example of global styles you may want to override
+// body {
+//   font-family: var(--font-family-primary);
+//   font-weight: var(--font-light);
+//   font-size: var(--font-size-base);
+//   line-height: 1.6;
+// }

--- a/packages/cli/src/templates/variables.scss
+++ b/packages/cli/src/templates/variables.scss
@@ -1,0 +1,11 @@
+// we're importing here main style variables
+@import '~@shopware-pwa/default-theme/assets/scss/variables';
+
+// For available variables check SFUI docs - https://docs.storefrontui.io/customization.html#global-variables
+// 
+// Please remember to ONLY override variables here, as it will be used in components. 
+// If you'd add some styles here as well it would be included in almost every component. You don't want it ;) You can add global styles in main.scss file.
+
+// #__nuxt {
+//   --c-primary: #5ece7b;
+// }

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -22,19 +22,13 @@
     ]
   },
   "license": "MIT",
-  "devDependencies": {
-    "@vue/composition-api": "^0.5.0",
-    "vue": "^2.6.11"
-  },
-  "peerDependencies": {
-    "@vue/composition-api": "^0.5.0",
-    "axios": "^0.19.2",
-    "vue": "^2.6.11"
-  },
   "dependencies": {
+    "axios": "^0.19.2",
+    "@vue/composition-api": "^0.5.0",
     "@shopware-pwa/shopware-6-client": "0.1.0-alpha.9",
     "cookie-universal": "^2.1.3",
-    "query-string": "^6.12.1"
+    "query-string": "^6.12.1",
+    "vue": "^2.6.11"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/default-theme/assets/scss/main.scss
+++ b/packages/default-theme/assets/scss/main.scss
@@ -1,0 +1,77 @@
+@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables.scss';
+
+// Global styles
+
+html {
+  overflow-x: hidden;
+  height: 100vh;
+}
+
+a {
+  text-decoration: none;
+  color: var(--c-link);
+  &:hover {
+    color: var(--c-link-hover);
+  }
+}
+
+/*Header styles*/
+h1 {
+  font-family: var(--font-family-secondary);
+  font-size: var(--h1-font-size);
+  font-weight: var(--h1-font-weight);
+  line-height: 1.6;
+  margin: 0;
+}
+
+h2 {
+  font-family: var(--font-family-secondary);
+  font-size: var(--h2-font-size);
+  font-weight: var(--h2-font-weight);
+  line-height: 1.6;
+  margin: 0;
+}
+
+h3 {
+  font-family: var(--font-family-secondary);
+  font-size: var(--h3-font-size);
+  font-weight: var(--h3-font-weight);
+  line-height: 1.6;
+  margin: 0;
+}
+
+h4 {
+  font-family: var(--font-family-secondary);
+  font-size: var(--h4-font-size);
+  font-weight: var(--h4-font-weight);
+  line-height: 1.6;
+  margin: 0;
+}
+
+h5 {
+  font-family: var(--font-family-secondary);
+  font-size: var(--h5-font-size);
+  font-weight: var(--h5-font-weight);
+  line-height: 1.6;
+  margin: 0;
+}
+
+body {
+  overflow-x: hidden;
+  padding: 0;
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-light);
+  font-size: var(--font-size-base);
+  line-height: 1.6;
+}
+
+#__nuxt {
+  height: 100vh;
+}
+
+#__layout {
+  height: 100%;
+}

--- a/packages/default-theme/assets/scss/main.scss
+++ b/packages/default-theme/assets/scss/main.scss
@@ -1,7 +1,7 @@
 @import '~@storefront-ui/vue/styles';
 @import '@/assets/scss/variables.scss';
 
-// Global styles
+// Global styles for theme
 
 html {
   overflow-x: hidden;

--- a/packages/default-theme/assets/scss/variables.scss
+++ b/packages/default-theme/assets/scss/variables.scss
@@ -3,5 +3,6 @@
 // Global variables
 
 #__nuxt {
-  --c-primary: #cbda44;
+  // TODO I'll change this color after first deployment preview as a check if everything is okay
+  --c-primary: #0d3fe4;
 }

--- a/packages/default-theme/assets/scss/variables.scss
+++ b/packages/default-theme/assets/scss/variables.scss
@@ -1,0 +1,7 @@
+@import '~@storefront-ui/shared/styles/variables';
+
+// Global variables
+
+#__nuxt {
+  --c-primary: #cbda44;
+}

--- a/packages/default-theme/assets/scss/variables.scss
+++ b/packages/default-theme/assets/scss/variables.scss
@@ -1,8 +1,7 @@
 @import '~@storefront-ui/shared/styles/variables';
 
-// Global variables
+// Global variables for theme
 
-#__nuxt {
-  // TODO I'll change this color after first deployment preview as a check if everything is okay
-  --c-primary: #0d3fe4;
-}
+// #__nuxt {
+//   --c-primary: #5ece7b;
+// }

--- a/packages/default-theme/cms/blocks/CmsBlockCenterText.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockCenterText.vue
@@ -38,7 +38,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .cms-block-center-text {
   display: flex;

--- a/packages/default-theme/cms/blocks/CmsBlockImageFourColumn.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockImageFourColumn.vue
@@ -42,7 +42,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .cms-block-image-four-column {
   display: flex;

--- a/packages/default-theme/cms/blocks/CmsBlockImageHighlightRow.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockImageHighlightRow.vue
@@ -38,7 +38,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .cms-block-image-highlight-row {
   display: flex;

--- a/packages/default-theme/cms/blocks/CmsBlockImageSimpleGrid.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockImageSimpleGrid.vue
@@ -40,7 +40,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .sw-image-simple-grid {
   display: flex;

--- a/packages/default-theme/cms/blocks/CmsBlockImageTextCover.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockImageTextCover.vue
@@ -34,7 +34,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .cms-block-image-text-cover {
   display: flex;

--- a/packages/default-theme/cms/blocks/CmsBlockImageThreeColumn.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockImageThreeColumn.vue
@@ -38,7 +38,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .cms-block-image-three-column {
   display: flex;

--- a/packages/default-theme/cms/blocks/CmsBlockImageThreeCover.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockImageThreeCover.vue
@@ -38,7 +38,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .cms-block-image-three-cover {
   display: flex;

--- a/packages/default-theme/cms/blocks/CmsBlockImageTwoColumn.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockImageTwoColumn.vue
@@ -34,7 +34,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .cms-block-image-two-column {
   display: flex;

--- a/packages/default-theme/components/SwAddressList.vue
+++ b/packages/default-theme/components/SwAddressList.vue
@@ -93,7 +93,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 .shipping-list {
   margin-bottom: var(--spacer-xl);
   width: 100%;

--- a/packages/default-theme/components/SwCart.vue
+++ b/packages/default-theme/components/SwCart.vue
@@ -119,7 +119,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 #cart {
   --sidebar-z-index: 4;
   & > * {

--- a/packages/default-theme/components/SwCartProduct.vue
+++ b/packages/default-theme/components/SwCartProduct.vue
@@ -91,7 +91,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .collected-product {
   --collected-product-actions-align-items: flex-end;

--- a/packages/default-theme/components/SwCurrency.vue
+++ b/packages/default-theme/components/SwCurrency.vue
@@ -62,7 +62,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .sw-currency {
   text-align: center;

--- a/packages/default-theme/components/SwFooter.vue
+++ b/packages/default-theme/components/SwFooter.vue
@@ -34,7 +34,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .sw-footer {
   width: 100%;

--- a/packages/default-theme/components/SwLanguageSwitcher.vue
+++ b/packages/default-theme/components/SwLanguageSwitcher.vue
@@ -38,7 +38,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .sw-language-switcher {
   --select-padding: 0;

--- a/packages/default-theme/components/SwLogin.vue
+++ b/packages/default-theme/components/SwLogin.vue
@@ -93,7 +93,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .sw-login {
   &__alert {

--- a/packages/default-theme/components/SwProductCarousel.vue
+++ b/packages/default-theme/components/SwProductCarousel.vue
@@ -54,7 +54,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .section {
   padding: 0 var(--spacer-base);

--- a/packages/default-theme/components/SwProductDetails.vue
+++ b/packages/default-theme/components/SwProductDetails.vue
@@ -223,7 +223,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 @mixin for-iOS {
   @supports (-webkit-overflow-scrolling: touch) {

--- a/packages/default-theme/components/SwProductTabs.vue
+++ b/packages/default-theme/components/SwProductTabs.vue
@@ -79,7 +79,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .product-details {
   &__tabs {

--- a/packages/default-theme/components/SwRegister.vue
+++ b/packages/default-theme/components/SwRegister.vue
@@ -250,7 +250,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .sw-login {
   &__alert {

--- a/packages/default-theme/components/SwResetPassword.vue
+++ b/packages/default-theme/components/SwResetPassword.vue
@@ -80,7 +80,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .sw-reset-password {
   &__alert {

--- a/packages/default-theme/components/SwTopNavigation.vue
+++ b/packages/default-theme/components/SwTopNavigation.vue
@@ -212,7 +212,7 @@ export default {
 </script>
 
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .top-navigation {
   --search-bar-width: 100%;

--- a/packages/default-theme/components/account/MyAddresses/Address.vue
+++ b/packages/default-theme/components/account/MyAddresses/Address.vue
@@ -105,7 +105,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .shipping {
   &:last-child {

--- a/packages/default-theme/components/checkout/sidebar/SidebarOrderReview.vue
+++ b/packages/default-theme/components/checkout/sidebar/SidebarOrderReview.vue
@@ -82,7 +82,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .review {
   box-sizing: border-box;

--- a/packages/default-theme/components/checkout/sidebar/SidebarOrderSummary.vue
+++ b/packages/default-theme/components/checkout/sidebar/SidebarOrderSummary.vue
@@ -108,7 +108,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 .title {
   --heading-title-margin: 0 0 var(--spacer-xl) 0;
 }

--- a/packages/default-theme/components/checkout/steps/OrderReviewStep.vue
+++ b/packages/default-theme/components/checkout/steps/OrderReviewStep.vue
@@ -85,7 +85,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .title {
   --heading-padding: var(--spacer-base) 0;

--- a/packages/default-theme/components/checkout/steps/PaymentStep.vue
+++ b/packages/default-theme/components/checkout/steps/PaymentStep.vue
@@ -81,7 +81,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 .title {
   --heading-padding: var(--spacer-base) 0;
   @include for-desktop {

--- a/packages/default-theme/components/checkout/steps/PersonalDetailsStep.vue
+++ b/packages/default-theme/components/checkout/steps/PersonalDetailsStep.vue
@@ -26,5 +26,5 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 </style>

--- a/packages/default-theme/components/checkout/steps/ShippingStep.vue
+++ b/packages/default-theme/components/checkout/steps/ShippingStep.vue
@@ -95,7 +95,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .title {
   --heading-padding: var(--spacer-base) 0;

--- a/packages/default-theme/components/checkout/steps/guest/BillingAddressGuestForm.vue
+++ b/packages/default-theme/components/checkout/steps/guest/BillingAddressGuestForm.vue
@@ -178,7 +178,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .form {
   margin-top: var(--spacer-base);

--- a/packages/default-theme/components/checkout/steps/guest/PersonalDetailsGuestForm.vue
+++ b/packages/default-theme/components/checkout/steps/guest/PersonalDetailsGuestForm.vue
@@ -342,7 +342,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .sw-checkout {
   &__personal_info {

--- a/packages/default-theme/components/checkout/steps/guest/ShippingAddressGuestForm.vue
+++ b/packages/default-theme/components/checkout/steps/guest/ShippingAddressGuestForm.vue
@@ -175,7 +175,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 .form {
   &__group {
     display: flex;

--- a/packages/default-theme/components/checkout/steps/user/BillingAddressUserForm.vue
+++ b/packages/default-theme/components/checkout/steps/user/BillingAddressUserForm.vue
@@ -20,5 +20,5 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 </style>

--- a/packages/default-theme/components/checkout/steps/user/PersonalDetailsUserForm.vue
+++ b/packages/default-theme/components/checkout/steps/user/PersonalDetailsUserForm.vue
@@ -34,7 +34,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .personal-details-user-form {
   &__proceed {

--- a/packages/default-theme/components/checkout/steps/user/ShippingAddressUserForm.vue
+++ b/packages/default-theme/components/checkout/steps/user/ShippingAddressUserForm.vue
@@ -20,5 +20,5 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 </style>

--- a/packages/default-theme/components/checkout/summary/BillingAddressSummary.vue
+++ b/packages/default-theme/components/checkout/summary/BillingAddressSummary.vue
@@ -36,7 +36,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 .review {
   &__item {
     display: flex;

--- a/packages/default-theme/components/checkout/summary/OrderItem.vue
+++ b/packages/default-theme/components/checkout/summary/OrderItem.vue
@@ -64,7 +64,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .sf-image {
   max-width: 80%;

--- a/packages/default-theme/components/checkout/summary/OrderItemsTable.vue
+++ b/packages/default-theme/components/checkout/summary/OrderItemsTable.vue
@@ -49,7 +49,7 @@ export default {
 }
 </script>
 <style lang="scss">
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 .product-sku {
   color: var(--c-text-muted);
 }

--- a/packages/default-theme/components/checkout/summary/PaymentMethodSummary.vue
+++ b/packages/default-theme/components/checkout/summary/PaymentMethodSummary.vue
@@ -31,7 +31,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 .review {
   &__item {
     display: flex;

--- a/packages/default-theme/components/checkout/summary/PersonalDetailsSummary.vue
+++ b/packages/default-theme/components/checkout/summary/PersonalDetailsSummary.vue
@@ -47,7 +47,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 .review {
   &__item {
     display: flex;

--- a/packages/default-theme/components/checkout/summary/ShippingAddressSummary.vue
+++ b/packages/default-theme/components/checkout/summary/ShippingAddressSummary.vue
@@ -44,7 +44,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 .review {
   &__item {
     display: flex;

--- a/packages/default-theme/components/checkout/summary/TotalsSummary.vue
+++ b/packages/default-theme/components/checkout/summary/TotalsSummary.vue
@@ -108,7 +108,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .summary {
   margin: 0 calc(var(--spacer-base) * -1);

--- a/packages/default-theme/components/forms/SwAddress.vue
+++ b/packages/default-theme/components/forms/SwAddress.vue
@@ -287,7 +287,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 .form {
   @include for-desktop {

--- a/packages/default-theme/components/forms/SwPassword.vue
+++ b/packages/default-theme/components/forms/SwPassword.vue
@@ -126,7 +126,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .sw-password {
   &__alert {

--- a/packages/default-theme/components/forms/SwPersonalInfo.vue
+++ b/packages/default-theme/components/forms/SwPersonalInfo.vue
@@ -210,7 +210,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .form {
   @include for-desktop {

--- a/packages/default-theme/components/modals/SwLoginModal.vue
+++ b/packages/default-theme/components/modals/SwLoginModal.vue
@@ -128,7 +128,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 #sw-login-modal {
   box-sizing: border-box;

--- a/packages/default-theme/components/views/ProductView.vue
+++ b/packages/default-theme/components/views/ProductView.vue
@@ -111,7 +111,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 @mixin for-iOS {
   @supports (-webkit-overflow-scrolling: touch) {

--- a/packages/default-theme/layouts/default.vue
+++ b/packages/default-theme/layouts/default.vue
@@ -71,81 +71,8 @@ export default {
 }
 </script>
 
-<style lang="scss">
-@import '~@storefront-ui/vue/styles';
-
-html {
-  overflow-x: hidden;
-  height: 100vh;
-}
-
-a {
-  text-decoration: none;
-  color: var(--c-link);
-  &:hover {
-    color: var(--c-link-hover);
-  }
-}
-
-/*Header styles*/
-h1 {
-  font-family: var(--font-family-secondary);
-  font-size: var(--h1-font-size);
-  font-weight: var(--h1-font-weight);
-  line-height: 1.6;
-  margin: 0;
-}
-
-h2 {
-  font-family: var(--font-family-secondary);
-  font-size: var(--h2-font-size);
-  font-weight: var(--h2-font-weight);
-  line-height: 1.6;
-  margin: 0;
-}
-
-h3 {
-  font-family: var(--font-family-secondary);
-  font-size: var(--h3-font-size);
-  font-weight: var(--h3-font-weight);
-  line-height: 1.6;
-  margin: 0;
-}
-
-h4 {
-  font-family: var(--font-family-secondary);
-  font-size: var(--h4-font-size);
-  font-weight: var(--h4-font-weight);
-  line-height: 1.6;
-  margin: 0;
-}
-
-h5 {
-  font-family: var(--font-family-secondary);
-  font-size: var(--h5-font-size);
-  font-weight: var(--h5-font-weight);
-  line-height: 1.6;
-  margin: 0;
-}
-
-body {
-  overflow-x: hidden;
-  padding: 0;
-  margin: 0;
-  min-height: 100vh;
-  font-family: var(--font-family-primary);
-  font-weight: var(--font-light);
-  font-size: var(--font-size-base);
-  line-height: 1.6;
-}
-
-#__nuxt {
-  height: 100vh;
-}
-
-#__layout {
-  height: 100%;
-}
+<style lang="scss" scoped>
+@import '@/assets/scss/variables';
 
 .layout {
   box-sizing: border-box;

--- a/packages/default-theme/layouts/error.vue
+++ b/packages/default-theme/layouts/error.vue
@@ -69,7 +69,7 @@ export default {
 }
 </script>
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 .error-page {
   box-sizing: border-box;
   text-align: center;

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -18,14 +18,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@nuxtjs/axios": "^5.10.1",
-    "@nuxtjs/pwa": "^3.0.0-beta.20",
     "@storefront-ui/vue": "0.7.11",
-    "@vue/composition-api": "^0.5.0",
     "currency.js": "^1.2.2",
     "dayjs": "^1.8.25",
-    "husky": "^4.2.5",
+    "node-sass": "^4.14.1",
     "nuxt": "^2.12.2",
+    "sass-loader": "^8.0.2",
     "vue-i18n": "^8.17.7",
     "vuelidate": "^0.7.5"
   },

--- a/packages/default-theme/pages/_lang/_.vue
+++ b/packages/default-theme/pages/_lang/_.vue
@@ -62,5 +62,5 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 </style>

--- a/packages/default-theme/pages/_lang/account.vue
+++ b/packages/default-theme/pages/_lang/account.vue
@@ -90,7 +90,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .my-account {
   @include for-desktop {

--- a/packages/default-theme/pages/_lang/account/addresses.vue
+++ b/packages/default-theme/pages/_lang/account/addresses.vue
@@ -60,7 +60,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 
 

--- a/packages/default-theme/pages/_lang/account/orders.vue
+++ b/packages/default-theme/pages/_lang/account/orders.vue
@@ -108,7 +108,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 .message {
   margin: 0 0 var(--spacer-xl) 0;
   color: var(--c-dark-variant);

--- a/packages/default-theme/pages/_lang/account/profile.vue
+++ b/packages/default-theme/pages/_lang/account/profile.vue
@@ -45,7 +45,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .notice {
   max-width: 31rem;

--- a/packages/default-theme/pages/_lang/checkout.vue
+++ b/packages/default-theme/pages/_lang/checkout.vue
@@ -91,7 +91,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles';
+@import '@/assets/scss/variables';
 
 #checkout {
   @include for-desktop {

--- a/packages/default-theme/pages/_lang/login.vue
+++ b/packages/default-theme/pages/_lang/login.vue
@@ -34,7 +34,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 #login {
   height: 65vh;
   margin-bottom: 10vh;

--- a/packages/default-theme/pages/_lang/success-page.vue
+++ b/packages/default-theme/pages/_lang/success-page.vue
@@ -59,7 +59,7 @@ export default {
 }
 </script>
 <style lang="scss">
-@import '~@storefront-ui/vue/styles.scss';
+@import '@/assets/scss/variables';
 
 .success-page {
   min-height: 50vh;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,17 +2445,6 @@
     webpack-node-externals "^1.7.2"
     webpackbar "^4.0.0"
 
-"@nuxtjs/axios@^5.10.1":
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/axios/-/axios-5.10.1.tgz#425d1f1d0c11283233cc91409e0e54b5ab72e433"
-  integrity sha512-SxHyEHsS47lCzPXGqvGIu/SzhoSJvlRRgQBfBR5YI31V9/YIlfTE0z+RqAkdmb5uoL+JR2gqIuFDTdk+qyX9Ww==
-  dependencies:
-    "@nuxtjs/proxy" "^1.3.3"
-    axios "^0.19.2"
-    axios-retry "^3.1.6"
-    consola "^2.11.3"
-    defu "^2.0.2"
-
 "@nuxtjs/eslint-config@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config/-/eslint-config-2.0.2.tgz#ff521ee1c0b875ac340f17ed656db213b6af854e"
@@ -2477,26 +2466,6 @@
   dependencies:
     consola "^2.10.1"
     eslint-loader "^3.0.0"
-
-"@nuxtjs/proxy@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/proxy/-/proxy-1.3.3.tgz#3de3d9f073e8e57167168100940be2a824a220e0"
-  integrity sha512-ykpCUdOqPOH79mQG30QfWZmbRD8yjTD+TTSBbwow5GkROUQEtXw+HE+q6i+YFpuChvgJNbwVrXdZ3YmfXbZtTw==
-  dependencies:
-    consola "^2.5.6"
-    http-proxy-middleware "^0.19.1"
-
-"@nuxtjs/pwa@^3.0.0-beta.20":
-  version "3.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/pwa/-/pwa-3.0.0-beta.20.tgz#56766da5485c09cb73307285292203f4a4417d5d"
-  integrity sha512-pZhGBqRvTCItvAdZ6PSZtqJUKT6ybphXCykfHh95KzW0cGf10QH/ETPci2AMDEzfx4jW2hImGSmLBToVWOV7Uw==
-  dependencies:
-    defu "^1.0.0"
-    execa "^1.0.0"
-    fs-extra "^8.1.0"
-    hasha "^5.0.0"
-    jimp-compact "^0.8.0"
-    workbox-cdn "^4.3.1"
 
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
@@ -4699,13 +4668,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
-axios-retry@^3.1.6:
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.1.7.tgz#600e234f88d38dd86e2e46d620ccace4ab03d3de"
-  integrity sha512-iF8yLLiS96MKaG4qSXhoDEpkZaA4XVs7FErWgIdYpy2RrVl+Hwc3JJ0lsFtPnL7ZAlE02Ocx56j/woxCh6iKHw==
-  dependencies:
-    is-retry-allowed "^1.1.0"
-
 axios@^0.19.0, axios@^0.19.2:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
@@ -6112,7 +6074,7 @@ connect@^3.7.0:
     parseurl "~1.3.3"
     utils-merge "1.0.1"
 
-consola@^2.10.0, consola@^2.10.1, consola@^2.11.0, consola@^2.11.3, consola@^2.5.6, consola@^2.6.0, consola@^2.9.0:
+consola@^2.10.0, consola@^2.10.1, consola@^2.11.0, consola@^2.11.3, consola@^2.6.0, consola@^2.9.0:
   version "2.11.3"
   resolved "https://registry.yarnpkg.com/consola/-/consola-2.11.3.tgz#f7315836224c143ac5094b47fd4c816c2cd1560e"
   integrity sha512-aoW0YIIAmeftGR8GSpw6CGQluNdkWMWh3yEFjH/hmynTYnMtibXszii3lxCXmk8YxJtI3FAK5aTiquA5VH68Gw==
@@ -7158,11 +7120,6 @@ defu@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defu/-/defu-1.0.0.tgz#43acb09dfcf81866fa3b0fc047ece18e5c30df71"
   integrity sha512-1Y1KRFxiiq+LYsZ3iP7xYSR8bHfmHFOUpDunZCN1ld1fGfDJWJIvkUBtjl3apnBwPuJtL/H7cwwlLYX8xPkraQ==
-
-defu@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/defu/-/defu-2.0.2.tgz#9a3d4c1330d60c0ed4812e51864b948c51f7ad45"
-  integrity sha512-E5dO3ji0TmVcZaB/2G6Ovu5zNHbWkgCU7v+EoE/Jj1Lbwv1BB6hNNKLkio2ZLI3/e3avlO634QUhQl4iCpm3Bg==
 
 degenerator@^1.0.4:
   version "1.0.4"
@@ -9388,14 +9345,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hasha@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/hasha/-/hasha-5.2.0.tgz#33094d1f69c40a4a6ac7be53d5fe3ff95a269e0c"
-  integrity sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==
-  dependencies:
-    is-stream "^2.0.0"
-    type-fest "^0.8.0"
-
 hast-util-parse-selector@^2.0.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz#60c99d0b519e12ab4ed32e58f150ec3f61ed1974"
@@ -9631,7 +9580,7 @@ http-proxy-agent@^2.1.0:
     agent-base "4"
     debug "3.1.0"
 
-http-proxy-middleware@0.19.1, http-proxy-middleware@^0.19.1:
+http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
   integrity sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==
@@ -10366,7 +10315,7 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
-is-retry-allowed@^1.0.0, is-retry-allowed@^1.1.0:
+is-retry-allowed@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
@@ -10906,11 +10855,6 @@ jest@^25.4.0:
     "@jest/core" "^25.4.0"
     import-local "^3.0.2"
     jest-cli "^25.4.0"
-
-jimp-compact@^0.8.0:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/jimp-compact/-/jimp-compact-0.8.5.tgz#4dd5be1df94111902a58e6e698cbbdea9bdc1e0b"
-  integrity sha512-BkpiX6jZyDVLU+CleO/6yF8SFHnyZXiElPryNjZx58AK1vy+bqSFvhKeFS680TISSr8IWqHlIAwDMMA0DTQkMw==
 
 jju@~1.4.0:
   version "1.4.0"
@@ -12596,6 +12540,29 @@ node-sass@^4.12.0:
     npmlog "^4.0.0"
     request "^2.88.0"
     sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
+
+node-sass@^4.14.1:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
+  integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash "^4.17.15"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.13.2"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "2.2.5"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
@@ -15666,6 +15633,16 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sass-graph@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.5.tgz#a981c87446b8319d96dce0671e487879bd24c2e8"
+  integrity sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==
+  dependencies:
+    glob "^7.0.0"
+    lodash "^4.0.0"
+    scss-tokenizer "^0.2.3"
+    yargs "^13.3.2"
+
 sass-graph@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
@@ -17647,7 +17624,7 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-type-fest@^0.8.0, type-fest@^0.8.1:
+type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
@@ -18755,11 +18732,6 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-workbox-cdn@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/workbox-cdn/-/workbox-cdn-4.3.1.tgz#f1ffed5368c20291048498ba0744baf27dbd7294"
-  integrity sha512-Adkgo+/7S+bBsDTzdeH0xxQCrfBM1EiyZlvu1tMh0cJ/ipC6TtA8KDr12PBREdbL0zO9hG+7OSzvi2NLchPAEg==
-
 worker-farm@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
@@ -18988,6 +18960,14 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^15.0.1:
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
@@ -19028,6 +19008,22 @@ yargs@12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^13.3.2:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"
 
 yargs@^14.2.2:
   version "14.2.3"


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #751 

Changes:
- theme has now `main.scss` file for global styles and `variables.scss` for variables
- `init` command creates a template for two files which are importing two mentioned above with ability to extend them
- imports in all components are changes from `~@storefront-ui/vue/styles` to local `@/assets/scss/variables` file which contains all variables from the theme, overridden with user preferences



<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
