### PR TITLE
refactor(default-theme): move SfButtons to SwButton atom

### DIFF
--- a/packages/default-theme/cms/elements/CmsElementCategoryNavigation.vue
+++ b/packages/default-theme/cms/elements/CmsElementCategoryNavigation.vue
@@ -11,20 +11,20 @@
           :key="accordion.id"
           :header="accordion.name"
         >
-          <template #header="{header, isOpen, accordionClick, showChevron}">
+          <template #header="{header, isOpen, accordionClick}">
             <div class="cms-element-category-navigation__menu-item">
               <nuxt-link
                 :to="getCategoryUrl(accordion.route)"
                 
               >
-                <SfButton
+                <SwButton
                   :aria-pressed="isOpen.toString()"
                   :aria-expanded="isOpen.toString()"
                   :class="{ 'sf-accordion-item__header--open': isOpen }"
                   class="sf-button--pure sf-accordion-item__header"
                 >
                 {{ header }}
-                </SfButton>
+                </SwButton>
               </nuxt-link>
               <SfChevron
                 tabindex="0"
@@ -61,9 +61,10 @@
 </template>
 
 <script>
-import { SfList, SfAccordion, SfMenuItem, SfHeading, SfChevron, SfButton } from '@storefront-ui/vue'
+import { SfList, SfAccordion, SfMenuItem, SfHeading, SfChevron } from '@storefront-ui/vue'
 import { getNavigation } from '@shopware-pwa/shopware-6-client'
 import { useCms } from '@shopware-pwa/composables'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   components: {
@@ -72,7 +73,7 @@ export default {
     SfMenuItem,
     SfHeading,
     SfChevron,
-    SfButton
+    SwButton
   },
   name: 'CmsElementCategoryNavigation',
   props: {

--- a/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
+++ b/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
@@ -3,13 +3,13 @@
     class="cms-element-category-navigation-sidebar-filter sw-navbar navbar section"
   >
     <div class="sw-navbar navbar__main">
-      <SfButton
+      <SwButton
         class="sf-button--text navbar__filters-button"
         @click="isFilterSidebarOpen = true"
       >
         <SfIcon size="14px" icon="filter" style="margin-right: 10px;" />
         Filters
-      </SfButton>
+      </SwButton>
       <div class="navbar__sort desktop-only">
         <span class="navbar__label">Sort by:</span>
         <SfSelect v-model="sortBy" :size="sorting.length" class="sort-by">
@@ -30,7 +30,7 @@
       </div>
       <div class="navbar__view">
         <span class="navbar__view-label desktop-only">View</span>
-        <SfButton
+        <SwButton
           class="sf-button--pure"
           aria-label="Change to grid view"
           :aria-pressed="isGridView.toString()"
@@ -42,8 +42,8 @@
             icon="tiles"
             size="12px"
           />
-        </SfButton>
-        <SfButton
+        </SwButton>
+        <SwButton
           class="sf-button--pure"
           aria-label="Change to list view"
           :aria-pressed="!isGridView.toString()"
@@ -55,7 +55,7 @@
             icon="list"
             size="12px"
           />
-        </SfButton>
+        </SwButton>
       </div>
       <SfSidebar
         title="Filters"
@@ -99,13 +99,13 @@
         </div>
         <template #content-bottom>
           <div class="filters__buttons">
-            <SfButton class="sf-button--full-width" @click="submitFilters()"
-              >Done</SfButton
+            <SwButton class="sf-button--full-width" @click="submitFilters()"
+              >Done</SwButton
             >
-            <SfButton
+            <SwButton
               class="sf-button--full-width filters__button-clear"
               @click="clearAllFilters()"
-              >Clear all</SfButton
+              >Clear all</SwButton
             >
           </div>
         </template>
@@ -116,7 +116,6 @@
 
 <script>
 import {
-  SfButton,
   SfIcon,
   SfSelect,
   SfFilter,
@@ -128,12 +127,13 @@ import {
   useProductListing,
 } from '@shopware-pwa/composables'
 import { getSortingLabel } from '@shopware-pwa/default-theme/helpers'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 const { availableFilters, availableSorting } = useCategoryFilters()
 
 export default {
   name: 'CmsElementCategorySidebarFilter',
   components: {
-    SfButton,
+    SwButton,
     SfIcon,
     SfSelect,
     SfFilter,

--- a/packages/default-theme/components/SwAddressList.vue
+++ b/packages/default-theme/components/SwAddressList.vue
@@ -18,7 +18,6 @@ import {
   SfProperty,
   SfTabs,
   SfList,
-  SfButton,
   SfIcon,
   SfBadge,
   SfCheckbox
@@ -32,7 +31,6 @@ export default {
     SfProperty,
     SfTabs,
     SfList,
-    SfButton,
     SfIcon,
     SfBadge,
     SfCheckbox,

--- a/packages/default-theme/components/SwBottomNavigation.vue
+++ b/packages/default-theme/components/SwBottomNavigation.vue
@@ -45,9 +45,9 @@
             </SfSelectOption>
             <!-- TODO: change .native to @click after https://github.com/DivanteLtd/storefront-ui/issues/1097 -->
             <SfSelectOption :value="'logout'">
-                <SfButton @click="logoutUser">
+                <SwButton @click="logoutUser">
                   Logout
-                </SfButton>
+                </SwButton>
             </SfSelectOption>
           </SfSelect>
         </template>
@@ -82,8 +82,7 @@ import {
   SfCircleIcon,
   SfIcon,
   SfSelect,
-  SfProductOption,
-  SfButton
+  SfProductOption
 } from '@storefront-ui/vue'
 import {
   useCartSidebar,
@@ -95,6 +94,7 @@ import {
 import { PAGE_ACCOUNT, PAGE_LOGIN } from '../helpers/pages'
 import SwCurrency from '@shopware-pwa/default-theme/components/SwCurrency'
 import { onMounted } from '@vue/composition-api'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'SwBottomNavigation',
@@ -105,7 +105,7 @@ export default {
     SfSelect,
     SfProductOption,
     SwCurrency,
-    SfButton
+    SwButton
   },
   data() {
     return {

--- a/packages/default-theme/components/SwCart.vue
+++ b/packages/default-theme/components/SwCart.vue
@@ -55,17 +55,20 @@
                 <SfPrice :regular="totalPrice | price" class="sf-price--big" />
               </template>
             </SfProperty>
-            <SfButton
+            <SwButton
               class="sf-button--full-width color-secondary"
               @click="goToCheckout()"
-              >{{ $t('Go to checkout') }}</SfButton
+              >{{ $t('Go to checkout') }}</SwButton
             >
             <SwPluginSlot name="sidecart-checkout-button-after" />
           </div>
           <div v-else>
-            <SfButton class="sf-button--full-width color-primary">
+            <SwButton
+              class="sf-button--full-width color-primary"
+              @click="toggleSidebar"
+            >
               {{ $t('Start shopping') }}
-            </SfButton>
+            </SwButton>
           </div>
         </transition>
       </template>
@@ -75,7 +78,6 @@
 <script>
 import {
   SfSidebar,
-  SfButton,
   SfProperty,
   SfPrice,
   SfHeading,
@@ -83,6 +85,7 @@ import {
 } from '@storefront-ui/vue'
 import { useCart, useCartSidebar } from '@shopware-pwa/composables'
 import SwCartProduct from '@shopware-pwa/default-theme/components/SwCartProduct'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 import { PAGE_CHECKOUT } from '@shopware-pwa/default-theme/helpers/pages'
 import SwPluginSlot from 'sw-plugins/SwPluginSlot'
 import { computed, onMounted, ref } from '@vue/composition-api'
@@ -91,13 +94,13 @@ export default {
   name: 'SwCart',
   components: {
     SfSidebar,
-    SfButton,
     SfHeading,
     SfImage,
     SfProperty,
     SfPrice,
     SwCartProduct,
     SwPluginSlot,
+    SwButton,
   },
   setup() {
     const { cartItems, count, totalPrice, removeProduct } = useCart()

--- a/packages/default-theme/components/SwCartProduct.vue
+++ b/packages/default-theme/components/SwCartProduct.vue
@@ -10,25 +10,26 @@
   >
     <template #actions>
       <div class="collected-product__actions">
-        <SfButton class="sf-button--text collected-product__actions-element">
+        <SwButton class="sf-button--text collected-product__actions-element">
           Save for later
-        </SfButton>
-        <SfButton class="sf-button--text collected-product__actions-element">
+        </SwButton>
+        <SwButton class="sf-button--text collected-product__actions-element">
           Add to compare
-        </SfButton>
+        </SwButton>
       </div>
     </template>
   </SfCollectedProduct>
 </template>
 <script>
-import { SfButton, SfProperty, SfCollectedProduct } from '@storefront-ui/vue'
+import { SfProperty, SfCollectedProduct } from '@storefront-ui/vue'
 import { getProductMainImageUrl } from '@shopware-pwa/helpers'
 import { useCart } from '@shopware-pwa/composables'
 import { ref, watch, computed } from '@vue/composition-api'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   components: {
-    SfButton,
+    SwButton,
     SfProperty,
     SfCollectedProduct,
   },

--- a/packages/default-theme/components/SwLogin.vue
+++ b/packages/default-theme/components/SwLogin.vue
@@ -30,28 +30,29 @@
         @blur="$v.password.$touch()"
       />
       <SwPluginSlot name="login-form-button">
-        <SfButton
+        <SwButton
           class="sf-button--full-width form__button"
           :disabled="isLoading"
           @click="invokeLogin"
         >
           Log in
-        </SfButton>
+        </SwButton>
       </SwPluginSlot>
     </div>
   </div>
 </template>
 
 <script>
-import { SfInput, SfButton, SfAlert } from '@storefront-ui/vue'
+import { SfInput, SfAlert } from '@storefront-ui/vue'
 import { validationMixin } from 'vuelidate'
 import { required, email } from 'vuelidate/lib/validators'
 import { useUser } from '@shopware-pwa/composables'
 import SwPluginSlot from 'sw-plugins/SwPluginSlot'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'SwLogin',
-  components: { SfButton, SfInput, SfAlert, SwPluginSlot },
+  components: { SwButton, SfInput, SfAlert, SwPluginSlot },
   mixins: [validationMixin],
   data() {
     return {

--- a/packages/default-theme/components/SwProductDetails.vue
+++ b/packages/default-theme/components/SwProductDetails.vue
@@ -49,11 +49,11 @@
       />
       <SwPluginSlot name="product-page-add-to-cart-button-after" />
       <div class="product-details__action desktop-only">
-        <SfButton class="sf-button--text product-details__action-button"
-          >Save for later</SfButton
+        <SwButton class="sf-button--text product-details__action-button"
+          >Save for later</SwButton
         >
-        <SfButton class="sf-button--text product-details__action-button"
-          >Add to compare</SfButton
+        <SwButton class="sf-button--text product-details__action-button"
+          >Add to compare</SwButton
         >
       </div>
     </div>
@@ -68,7 +68,6 @@
 <script>
 import {
   SfAlert,
-  SfButton,
   SfProductOption,
   SfAddToCart,
 } from '@storefront-ui/vue'
@@ -88,13 +87,14 @@ import SwProductHeading from '@shopware-pwa/default-theme/components/SwProductHe
 import SwProductSelect from '@shopware-pwa/default-theme/components/SwProductSelect'
 import SwProductColors from '@shopware-pwa/default-theme/components/SwProductColors'
 import SwPluginSlot from 'sw-plugins/SwPluginSlot'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 import SwProductTabs from '@shopware-pwa/default-theme/components/SwProductTabs'
 export default {
   name: 'SwProductDetails',
   components: {
     SfAlert,
-    SfButton,
+    SwButton,
     SfProductOption,
     SfAddToCart,
     SwProductHeading,

--- a/packages/default-theme/components/SwRegister.vue
+++ b/packages/default-theme/components/SwRegister.vue
@@ -106,20 +106,20 @@
           {{ countryOption.name }}
         </SfSelectOption>
       </SfSelect>
-      <SfButton
+      <SwButton
         class="sf-button--full-width form__button"
         :disabled="isLoading"
         @click="invokeRegister"
       >
         Create an account
-      </SfButton>
+      </SwButton>
     </div>
   </div>
 </template>
 
 <script>
 import { computed } from '@vue/composition-api'
-import { SfAlert, SfInput, SfButton, SfSelect } from '@storefront-ui/vue'
+import { SfAlert, SfInput, SfSelect } from '@storefront-ui/vue'
 import { validationMixin } from 'vuelidate'
 import { required, email, minLength } from 'vuelidate/lib/validators'
 import {
@@ -129,10 +129,11 @@ import {
 } from '@shopware-pwa/composables'
 import { mapCountries, mapSalutations } from '@shopware-pwa/helpers'
 import SwPluginSlot from 'sw-plugins/SwPluginSlot'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'SwResetPassword',
-  components: { SfButton, SfInput, SfAlert, SfSelect, SwPluginSlot },
+  components: { SwButton, SfInput, SfAlert, SfSelect, SwPluginSlot },
   mixins: [validationMixin],
   data() {
     return {

--- a/packages/default-theme/components/SwResetPassword.vue
+++ b/packages/default-theme/components/SwResetPassword.vue
@@ -17,12 +17,12 @@
         error-message="Valid email is required"
         @blur="$v.email.$touch()"
       />
-      <SfButton
+      <SwButton
         class="sf-button--full-width form__button"
         @click="invokeResetPassword"
       >
         Resend password
-      </SfButton>
+      </SwButton>
     </div>
     <SfHeading
       v-if="emailSent"
@@ -34,14 +34,15 @@
 </template>
 
 <script>
-import { SfInput, SfButton, SfAlert, SfHeading } from '@storefront-ui/vue'
+import { SfInput, SfAlert, SfHeading } from '@storefront-ui/vue'
 import { validationMixin } from 'vuelidate'
 import { required, email } from 'vuelidate/lib/validators'
 import {useUser} from '@shopware-pwa/composables';
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'SwResetPassword',
-  components: { SfButton, SfInput, SfAlert, SfHeading },
+  components: { SwButton, SfInput, SfAlert, SfHeading },
   mixins: [validationMixin],
   data() {
     return {

--- a/packages/default-theme/components/SwTopNavigation.vue
+++ b/packages/default-theme/components/SwTopNavigation.vue
@@ -76,9 +76,9 @@
                   </nuxt-link>
                 </SfListItem>
                 <SfListItem>
-                  <SfButton class="sf-button sf-button--full-width sf-button--underlined color-primary dropdown__item" @click="logoutUser()">
+                  <SwButton class="sf-button sf-button--full-width sf-button--underlined color-primary dropdown__item" @click="logoutUser()">
                     Logout
-                  </SfButton>
+                  </SwButton>
                 </SfListItem>
               </SfList>
             </SfDropdown>
@@ -110,7 +110,6 @@ import {
   SfImage,
   SfSearchBar,
   SfList,
-  SfButton,
   SfDropdown,
   SfOverlay,
   SfTopBar,
@@ -134,6 +133,7 @@ import { getCategoryUrl } from '@shopware-pwa/helpers'
 import SwPluginSlot from 'sw-plugins/SwPluginSlot'
 import { getAvailableLanguages } from '@shopware-pwa/shopware-6-client'
 import { useLocales } from '@shopware-pwa/default-theme/logic'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   components: {
@@ -143,14 +143,13 @@ export default {
     SfSearchBar,
     SfDropdown,
     SfList,
-    SfButton,
     SwMegaMenu,
     SfOverlay,
     SfTopBar,
     SwCurrency,
     SwLanguageSwitcher,
     SfIcon,
-    SfButton,
+    SwButton,
     SwPluginSlot,
   },
   setup() {

--- a/packages/default-theme/components/account/MyAddresses/Address.vue
+++ b/packages/default-theme/components/account/MyAddresses/Address.vue
@@ -58,12 +58,12 @@
 </template>
 <script>
 
-import { SfProperty, SfTabs, SfList, SfButton, SfIcon, SfBadge, SfCheckbox } from '@storefront-ui/vue'
+import { SfIcon } from '@storefront-ui/vue'
 import { useUser } from '@shopware-pwa/composables'
 
 export default {
   name: "Address",
-  components: {SfProperty, SfTabs, SfList, SfButton, SfIcon, SfBadge, SfCheckbox},
+  components: {SfIcon},
   props: {
     address: {
       type: Object,

--- a/packages/default-theme/components/atoms/SwButton.vue
+++ b/packages/default-theme/components/atoms/SwButton.vue
@@ -1,0 +1,21 @@
+<template>
+  <SfButton v-bind="{...$props, ...$attrs}" v-on="$listeners">
+    <slot />
+  </SfButton>
+</template>
+
+<script>
+import { SfButton } from '@storefront-ui/vue'
+
+export default {
+  name: 'SwButton',
+  components: {
+    SfButton,
+  },
+  setup() {
+    return {}
+  },
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/default-theme/components/checkout/sidebar/SidebarOrderReview.vue
+++ b/packages/default-theme/components/checkout/sidebar/SidebarOrderReview.vue
@@ -33,7 +33,6 @@
 <script>
 import {
   SfHeading,
-  SfButton,
   SfInput,
   SfCircleIcon,
   SfCharacteristic,
@@ -47,7 +46,6 @@ export default {
   name: 'SidebarOrderReview',
   components: {
     SfHeading,
-    SfButton,
     SfInput,
     SfCircleIcon,
     SfCharacteristic,

--- a/packages/default-theme/components/checkout/steps/PaymentStep.vue
+++ b/packages/default-theme/components/checkout/steps/PaymentStep.vue
@@ -26,39 +26,40 @@
         </SfRadio>
       </div>
       <div class="form__action">
-        <SfButton
+        <SwButton
           class="sf-button--full-width form__action-button form__action-button--secondary color-secondary desktop-only"
           @click="$emit('click:back')"
         >
           Go back to Shipping
-        </SfButton>
-        <SfButton
+        </SwButton>
+        <SwButton
           class="sf-button--full-width form__action-button"
           @click="$emit('proceed')"
-          >Review order</SfButton
+          >Review order</SwButton
         >
-        <SfButton
+        <SwButton
           class="sf-button--full-width sf-button--text form__action-button form__action-button--secondary mobile-only"
           @click="$emit('click:back')"
         >
           Go back to Shipping
-        </SfButton>
+        </SwButton>
       </div>
     </div>
   </div>
 </template>
 <script>
-import { SfHeading, SfButton, SfRadio } from '@storefront-ui/vue'
+import { SfHeading, SfRadio } from '@storefront-ui/vue'
 import BillingAddressGuestForm from '@shopware-pwa/default-theme/components/checkout/steps/guest/BillingAddressGuestForm'
 import BillingAddressUserForm from '@shopware-pwa/default-theme/components/checkout/steps/user/BillingAddressUserForm'
 import { useCheckout, useSessionContext } from '@shopware-pwa/composables'
 import { onMounted, computed } from '@vue/composition-api'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'PaymentStep',
   components: {
     SfHeading,
-    SfButton,
+    SwButton,
     SfRadio,
     BillingAddressGuestForm,
     BillingAddressUserForm,

--- a/packages/default-theme/components/checkout/steps/ShippingStep.vue
+++ b/packages/default-theme/components/checkout/steps/ShippingStep.vue
@@ -35,25 +35,25 @@
         </SfRadio>
       </div>
       <div class="form__action">
-        <SfButton class="form__action-button color-secondary desktop-only"
-          >Go Back to Personal details</SfButton
+        <SwButton class="form__action-button color-secondary desktop-only"
+          >Go Back to Personal details</SwButton
         >
-        <SfButton
+        <SwButton
           class="sf-button--full-width form__action-button"
           @click="$emit('proceed')"
-          >Continue to payment</SfButton
+          >Continue to payment</SwButton
         >
-        <SfButton
+        <SwButton
           class="sf-button--full-width sf-button--text form__action-button form__action-button--secondary mobile-only"
           @click="$emit('retreat')"
-          >Go back to Personal details</SfButton
+          >Go back to Personal details</SwButton
         >
       </div>
     </div>
   </div>
 </template>
 <script>
-import { SfHeading, SfButton, SfRadio, SfAlert } from '@storefront-ui/vue'
+import { SfHeading, SfRadio, SfAlert } from '@storefront-ui/vue'
 import { computed, onMounted } from '@vue/composition-api'
 import ShippingAddressGuestForm from '@shopware-pwa/default-theme/components/checkout/steps/guest/ShippingAddressGuestForm'
 import ShippingAddressUserForm from '@shopware-pwa/default-theme/components/checkout/steps/user/ShippingAddressUserForm'
@@ -62,12 +62,13 @@ import {
   useSessionContext,
   useCart,
 } from '@shopware-pwa/composables'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'ShippingStep',
   components: {
     SfHeading,
-    SfButton,
+    SwButton,
     SfRadio,
     SfAlert,
     ShippingAddressGuestForm,

--- a/packages/default-theme/components/checkout/steps/guest/BillingAddressGuestForm.vue
+++ b/packages/default-theme/components/checkout/steps/guest/BillingAddressGuestForm.vue
@@ -103,7 +103,6 @@
 import {
   SfHeading,
   SfInput,
-  SfButton,
   SfSelect,
   SfRadio,
   SfImage,
@@ -123,7 +122,6 @@ export default {
   components: {
     SfHeading,
     SfInput,
-    SfButton,
     SfSelect,
     SfRadio,
     SfImage,

--- a/packages/default-theme/components/checkout/steps/guest/PersonalDetailsGuestForm.vue
+++ b/packages/default-theme/components/checkout/steps/guest/PersonalDetailsGuestForm.vue
@@ -2,10 +2,10 @@
   <div class="sw-checkout__personal_info">
     <div class="log-in">
       <div class="log-in__buttons-container">
-        <SfButton
+        <SwButton
           @click="toggleLoginModal()"
           class="log-in__button color-secondary"
-          >Log in to your account</SfButton
+          >Log in to your account</SwButton
         >
         <SwPluginSlot name="checkout-login-after" />
       </div>
@@ -102,18 +102,18 @@
         />
       </transition>
       <div class="form__action">
-        <SfButton
+        <SwButton
           class="sf-button--full-width form__action-button form__action-button--secondary color-secondary desktop-only"
-          >Go Back to shop</SfButton
+          >Go Back to shop</SwButton
         >
-        <SfButton
+        <SwButton
           class="sf-button--full-width form__action-button"
           @click="toShipping"
-          >Continue to shipping</SfButton
+          >Continue to shipping</SwButton
         >
-        <SfButton
+        <SwButton
           class="sf-button--full-width sf-button--text form__action-button form__action-button--secondary mobile-only"
-          >Go back to shop</SfButton
+          >Go back to shop</SwButton
         >
       </div>
     </div>
@@ -127,7 +127,6 @@
 import {
   SfInput,
   SfCheckbox,
-  SfButton,
   SfHeading,
   SfModal,
   SfCharacteristic,
@@ -136,6 +135,7 @@ import {
   SfAlert,
 } from '@storefront-ui/vue'
 import SwPluginSlot from 'sw-plugins/SwPluginSlot'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 import { validationMixin } from 'vuelidate'
 import {
@@ -168,7 +168,7 @@ export default {
   components: {
     SfInput,
     SfCheckbox,
-    SfButton,
+    SwButton,
     SfHeading,
     SfModal,
     SfCharacteristic,

--- a/packages/default-theme/components/checkout/steps/guest/ShippingAddressGuestForm.vue
+++ b/packages/default-theme/components/checkout/steps/guest/ShippingAddressGuestForm.vue
@@ -95,7 +95,6 @@
 import {
   SfHeading,
   SfInput,
-  SfButton,
   SfSelect,
   SfRadio,
 } from '@storefront-ui/vue'
@@ -113,7 +112,6 @@ export default {
   components: {
     SfHeading,
     SfInput,
-    SfButton,
     SfSelect,
     SfRadio,
   },

--- a/packages/default-theme/components/checkout/steps/user/PersonalDetailsUserForm.vue
+++ b/packages/default-theme/components/checkout/steps/user/PersonalDetailsUserForm.vue
@@ -9,22 +9,23 @@
         />
       </template>
     </SwPersonalInfo>
-    <SfButton
+    <SwButton
       class="personal-details-user-form__proceed"
       @click="$emit('proceed')"
     >
       Continue to shipping
-    </SfButton>
+    </SwButton>
   </div>
 </template>
 <script>
-import { SfButton, SfHeading } from '@storefront-ui/vue'
+import { SfHeading } from '@storefront-ui/vue'
 import SwPersonalInfo from '@shopware-pwa/default-theme/components/forms/SwPersonalInfo'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'ShippingAddressUserForm',
   components: {
-    SfButton,
+    SwButton,
     SfHeading,
     SwPersonalInfo,
   },

--- a/packages/default-theme/components/checkout/summary/BillingAddressSummary.vue
+++ b/packages/default-theme/components/checkout/summary/BillingAddressSummary.vue
@@ -11,21 +11,21 @@
         {{ billingAddress.phoneNumber }}
       </p>
     </div>
-    <SfButton
+    <SwButton
       class="sf-button--text review__edit"
       @click="$emit('click:edit', 2)"
-      >Edit</SfButton
+      >Edit</SwButton
     >
   </div>
 </template>
 <script>
-import { SfButton } from '@storefront-ui/vue'
 import { useCheckout } from '@shopware-pwa/composables'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'BillingAddressSummary',
   components: {
-    SfButton,
+    SwButton,
   },
   setup() {
     const { billingAddress } = useCheckout()

--- a/packages/default-theme/components/checkout/summary/PaymentMethodSummary.vue
+++ b/packages/default-theme/components/checkout/summary/PaymentMethodSummary.vue
@@ -4,21 +4,21 @@
       <h4 class="review__title">Payment method</h4>
       <p class="content">{{ paymentMethod.name }}</p>
     </div>
-    <SfButton
+    <SwButton
       class="sf-button--text review__edit"
       @click="$emit('click:edit', 2)"
-      >Edit</SfButton
+      >Edit</SwButton
     >
   </div>
 </template>
 <script>
-import { SfButton } from '@storefront-ui/vue'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 import { useSessionContext } from '@shopware-pwa/composables'
 import { computed } from '@vue/composition-api'
 export default {
   name: 'PaymentMethodSummary',
   components: {
-    SfButton,
+    SwButton,
   },
   setup() {
     const { sessionContext } = useSessionContext()

--- a/packages/default-theme/components/checkout/summary/PersonalDetailsSummary.vue
+++ b/packages/default-theme/components/checkout/summary/PersonalDetailsSummary.vue
@@ -7,15 +7,15 @@
         {{ email }}
       </p>
     </div>
-    <SfButton
+    <SwButton
       class="sf-button--text review__edit"
       @click="$emit('click:edit', CHECKOUT_STEPS.PERSONAL_DETAILS)"
-      >Edit</SfButton
+      >Edit</SwButton
     >
   </div>
 </template>
 <script>
-import { SfButton } from '@storefront-ui/vue'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 import { usePersonalDetailsStep } from '@shopware-pwa/default-theme/logic/checkout/usePersonalDetailsStep'
 import { CHECKOUT_STEPS } from '@shopware-pwa/default-theme/logic/checkout'
 import { useCheckout, useUser } from '@shopware-pwa/composables'
@@ -24,7 +24,7 @@ import { computed } from '@vue/composition-api'
 export default {
   name: 'PersonalDetailsSummary',
   components: {
-    SfButton,
+    SwButton,
   },
   setup() {
     const { firstName, lastName, email } = usePersonalDetailsStep()

--- a/packages/default-theme/components/checkout/summary/ShippingAddressSummary.vue
+++ b/packages/default-theme/components/checkout/summary/ShippingAddressSummary.vue
@@ -17,20 +17,20 @@
         {{ shippingAddress.phoneNumber }}
       </p>
     </div>
-    <SfButton
+    <SwButton
       class="sf-button--text review__edit"
       @click="$emit('click:edit', 1)"
-      >Edit</SfButton
+      >Edit</SwButton
     >
   </div>
 </template>
 <script>
-import { SfButton } from '@storefront-ui/vue'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 import { useSessionContext, useCheckout } from '@shopware-pwa/composables'
 export default {
   name: 'ShippingAddressSummary',
   components: {
-    SfButton,
+    SwButton,
   },
   setup() {
     const { shippingMethod, sessionContext } = useSessionContext()

--- a/packages/default-theme/components/checkout/summary/TotalsSummary.vue
+++ b/packages/default-theme/components/checkout/summary/TotalsSummary.vue
@@ -43,24 +43,24 @@
       />
     </div>
     <div class="summary__action">
-      <SfButton
+      <SwButton
         class="sf-button--full-width summary__action-button summary__action-button--secondary color-secondary desktop-only"
         @click="$emit('click:back')"
       >
         Go back to Payment
-      </SfButton>
-      <SfButton
+      </SwButton>
+      <SwButton
         :disabled="!cartItems.length"
         class="sf-button--full-width summary__action-button"
         @click="$emit('proceed')"
-        >Place my order</SfButton
+        >Place my order</SwButton
       >
-      <SfButton
+      <SwButton
         class="sf-button--full-width sf-button--text summary__action-button summary__action-button--secondary mobile-only"
         @click="$emit('click:back')"
       >
         Go back to Payment
-      </SfButton>
+      </SwButton>
     </div>
   </div>
 </template>
@@ -72,16 +72,17 @@ import {
   SfProperty,
   SfCheckbox,
   SfHeading,
-  SfButton,
   SfNotification,
 } from '@storefront-ui/vue'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
+
 export default {
   name: 'TotalsSummary',
   components: {
     SfProperty,
     SfHeading,
     SfCheckbox,
-    SfButton,
+    SwButton,
     SfNotification,
   },
   data() {

--- a/packages/default-theme/components/forms/SwAddress.vue
+++ b/packages/default-theme/components/forms/SwAddress.vue
@@ -125,15 +125,15 @@
         required
         class="form__element"
       />
-      <SfButton class="form__button" @click="updateAddress">
+      <SwButton class="form__button" @click="updateAddress">
         Update the address
-      </SfButton>
-      <SfButton
+      </SwButton>
+      <SwButton
         class="sf-button--outline form__button form__button--back"
         @click="returnToAddresses"
       >
         Back
-      </SfButton>
+      </SwButton>
     </div>
   </div>
 </template>
@@ -146,7 +146,6 @@ import {
   SfAlert,
   SfTabs,
   SfInput,
-  SfButton,
   SfSelect,
   SfIcon
 } from '@storefront-ui/vue'
@@ -156,10 +155,11 @@ import {
   useSalutations
 } from '@shopware-pwa/composables'
 import { mapCountries, mapSalutations } from '@shopware-pwa/helpers'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'SwAddress',
-  components: { SfAlert, SfTabs, SfInput, SfButton, SfSelect, SfIcon },
+  components: { SfAlert, SfTabs, SfInput, SwButton, SfSelect, SfIcon },
   mixins: [validationMixin],
   props: {
     address: {

--- a/packages/default-theme/components/forms/SwPassword.vue
+++ b/packages/default-theme/components/forms/SwPassword.vue
@@ -52,13 +52,13 @@
               class="form__element form__element--half form__element--half-even"
               @blur="$v.newPasswordConfirm.$touch()"
             />
-            <SfButton
+            <SwButton
               class="form__button"
               :disabled="$v.$invalid"
               @click="invokeUpdate"
             >
               Update password
-            </SfButton>
+            </SwButton>
           </div>
         </slot>
       </div>
@@ -70,13 +70,14 @@
 import { validationMixin } from 'vuelidate'
 import { required, minLength, sameAs } from 'vuelidate/lib/validators'
 import { computed } from '@vue/composition-api';
-import { SfInput, SfButton, SfAlert } from '@storefront-ui/vue'
+import { SfInput, SfAlert } from '@storefront-ui/vue'
 import { useUser } from '@shopware-pwa/composables'
 import { getMessagesFromErrorsArray } from '@shopware-pwa/helpers'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'SwPassword',
-  components: { SfInput, SfButton, SfAlert },
+  components: { SfInput, SwButton, SfAlert },
   mixins: [validationMixin],
   props: {},
   setup() {

--- a/packages/default-theme/components/forms/SwPersonalInfo.vue
+++ b/packages/default-theme/components/forms/SwPersonalInfo.vue
@@ -68,13 +68,13 @@
             required
             @blur="$v.password.$touch()"
           />
-          <SfButton
+          <SwButton
             class="form__button"
             :disabled="$v.$invalid && !isEmailChanging && !isNameChanging"
             @click="invokeUpdate"
           >
             Save Changes
-          </SfButton>
+          </SwButton>
         </slot>
       </div>
     </slot>
@@ -87,19 +87,19 @@ import { validationMixin } from 'vuelidate'
 import { required, email, requiredIf, minLength, sameAs } from 'vuelidate/lib/validators'
 import {
   SfInput,
-  SfButton,
   SfSelect,
   SfProductOption,
   SfAlert
 } from '@storefront-ui/vue'
 import { useUser, useContext } from '@shopware-pwa/composables'
 import { mapSalutations, getMessagesFromErrorsArray } from '@shopware-pwa/helpers'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'SwPersonalInfo',
   components: {
     SfInput,
-    SfButton,
+    SwButton,
     SfSelect,
     SfProductOption,
     SfAlert

--- a/packages/default-theme/components/modals/SwLoginModal.vue
+++ b/packages/default-theme/components/modals/SwLoginModal.vue
@@ -10,12 +10,12 @@
         <div class="sw-login-modal__wrapper">
           <component :is="component" :key="key" @success="toggleModal" />
           <div v-if="component !== 'SwResetPassword'" class="action">
-            <SfButton
+            <SwButton
               class="sf-button--text button--muted"
               @click="component = 'SwResetPassword'"
             >
               Forgotten password?
-            </SfButton>
+            </SwButton>
           </div>
 
           <div class="bottom">
@@ -25,21 +25,21 @@
                 :level="4"
                 class="bottom__heading"
               />
-              <SfButton
+              <SwButton
                 class="sf-button--text bottom__element"
                 @click="component = 'SwRegister'"
               >
                 Register today?
-              </SfButton>
+              </SwButton>
             </template>
           </div>
           <div v-if="component !== 'SwLogin'" class="action">
-            <SfButton
+            <SwButton
               class="sf-button--text button--muted"
               @click="component = 'SwLogin'"
             >
               or try to log in again.
-            </SfButton>
+            </SwButton>
           </div>
         </div>
       </transition>
@@ -48,9 +48,10 @@
 </template>
 
 <script>
-import { SfButton, SfHeading, SfModal, SfAlert } from '@storefront-ui/vue'
+import { SfHeading, SfModal, SfAlert } from '@storefront-ui/vue'
 import { useUser, useUserLoginModal } from '@shopware-pwa/composables'
 import SwLogin from '@shopware-pwa/default-theme/components/SwLogin'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 const SwRegister = () =>
   import('@shopware-pwa/default-theme/components/SwRegister')
 const SwResetPassword = () =>
@@ -60,7 +61,7 @@ export default {
   name: 'SwLoginModal',
   components: {
     SfAlert,
-    SfButton,
+    SwButton,
     SfHeading,
     SfModal,
     SwLogin,

--- a/packages/default-theme/layouts/error.vue
+++ b/packages/default-theme/layouts/error.vue
@@ -11,25 +11,26 @@
       :subtitle="message"
     />
     <div class="error-page__actions">
-      <SfButton class="error-page__actions-button" @click="$router.push($i18n.path('/'))">
+      <SwButton class="error-page__actions-button" @click="$router.push($i18n.path('/'))">
         <SfIcon
           class="error-page__actions-button-icon"
           icon="chevron_left"
           color="white"
           size="20px"
         />Return to homepage
-      </SfButton>
-      <SfButton
+      </SwButton>
+      <SwButton
         @click="$router.back()"
         class="sf-button--full-width sf-button--text error-page__actions-button"
       >
         Back
-      </SfButton>
+      </SwButton>
     </div>
   </div>
 </template>
 <script>
-import { SfHeading, SfButton, SfIcon, SfImage } from '@storefront-ui/vue'
+import { SfHeading, SfIcon, SfImage } from '@storefront-ui/vue'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 const customMessageDictionary = {
   404: "We can't find what you are looking for. Are you lost?",
@@ -45,7 +46,7 @@ export default {
   name: 'ErrorPage',
   components: {
     SfHeading,
-    SfButton,
+    SwButton,
     SfImage,
     SfIcon,
   },

--- a/packages/default-theme/pages/_lang/account/addresses.vue
+++ b/packages/default-theme/pages/_lang/account/addresses.vue
@@ -11,9 +11,9 @@
             with each order.
           </p>
           <sw-address-list @editAddress="editAddress" />
-          <SfButton class="action-button" @click="changeAddress">
+          <SwButton class="action-button" @click="changeAddress">
             Add new address
-          </SfButton>
+          </SwButton>
         </SfTab>
       </SfTabs>
       <SfTabs v-else>
@@ -24,14 +24,15 @@
   </div>
 </template>
 <script>
-import { SfTabs, SfButton } from '@storefront-ui/vue'
+import { SfTabs } from '@storefront-ui/vue'
 import { useUser } from '@shopware-pwa/composables'
 import SwAddressList from '@shopware-pwa/default-theme/components/SwAddressList.vue'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'MyAddresses',
   components: {
-    SfButton,
+    SwButton,
     SfTabs,
     SwAddressList
   },

--- a/packages/default-theme/pages/_lang/account/orders.vue
+++ b/packages/default-theme/pages/_lang/account/orders.vue
@@ -46,8 +46,8 @@
             <template v-else>{{ data }}</template>
           </SfTableData>
           <!-- <SfTableData class="orders__view">
-            <SfButton class="sf-button--text mobile-only">Download</SfButton>
-            <SfButton class="sf-button--text desktop-only">VIEW</SfButton>
+            <SwButton class="sf-button--text mobile-only">Download</SwButton>
+            <SwButton class="sf-button--text desktop-only">VIEW</SwButton>
           </SfTableData> -->
         </SfTableRow>
       </SfTable>
@@ -59,15 +59,14 @@ import {
   SfTabs,
   SfList,
   SfDivider,
-  SfTable,
-  SfButton,
+  SfTable
 } from '@storefront-ui/vue'
 import { useUser } from '@shopware-pwa/composables'
 import { formatDate, formatPrice } from '@shopware-pwa/default-theme/helpers'
 
 export default {
   name: 'OrderHistory',
-  components: { SfTabs, SfList, SfDivider, SfTable, SfButton },
+  components: { SfTabs, SfList, SfDivider, SfTable },
   props: {},
   data() {
     return {

--- a/packages/default-theme/pages/_lang/account/profile.vue
+++ b/packages/default-theme/pages/_lang/account/profile.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script>
-import { SfTabs, SfInput, SfButton } from '@storefront-ui/vue'
+import { SfTabs, SfInput } from '@storefront-ui/vue'
 import { useUser } from '@shopware-pwa/composables'
 import SwPassword from '@shopware-pwa/default-theme/components/forms/SwPassword'
 import SwPersonalInfo from '@shopware-pwa/default-theme/components/forms/SwPersonalInfo'
@@ -34,7 +34,6 @@ export default {
   components: {
     SfTabs,
     SfInput,
-    SfButton,
     SwPassword,
     SwPersonalInfo,
   },

--- a/packages/default-theme/pages/_lang/success-page.vue
+++ b/packages/default-theme/pages/_lang/success-page.vue
@@ -1,22 +1,22 @@
 <template>
   <div class="success-page" :key="$route.fullPath">
     <a :href="paymentUrl" v-if="paymentUrl">
-      <SfButton>
+      <SwButton>
         Pay for your order
-      </SfButton>
+      </SwButton>
     </a>
     <SfHeading
       title="Thank you"
       subtitle="for shopping with us!"
       class="success-page__heading"
     />
-    <SfButton @click="$router.push($i18n.path('/'))">
+    <SwButton @click="$router.push($i18n.path('/'))">
       <SfIcon icon="chevron_left" color="white" size="20px" />Return to homepage
-    </SfButton>
+    </SwButton>
   </div>
 </template>
 <script>
-import { SfButton, SfHeading, SfIcon } from '@storefront-ui/vue'
+import { SfHeading, SfIcon } from '@storefront-ui/vue'
 import { getOrderPaymentUrl } from '@shopware-pwa/shopware-6-client'
 import {
   ref,
@@ -24,12 +24,13 @@ import {
   onMounted,
   computed,
 } from '@vue/composition-api'
+import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
 
 export default {
   name: 'SuccessPage',
   components: {
     SfHeading,
-    SfButton,
+    SwButton,
     SfIcon,
   },
   data() {

--- a/packages/default-theme/store/index.js
+++ b/packages/default-theme/store/index.js
@@ -3,7 +3,6 @@ export const state = () => ({
   page: null,
   user: null,
   sessionContext: null,
-  cartSidebarOpen: false,
   locales: ['en-GB', 'de-DE'],
   locale: 'en-GB',
   isGridView: true,
@@ -22,9 +21,6 @@ export const mutations = {
   SET_SESSION_CONTEXT(state, sessionContext) {
     state.sessionContext = sessionContext
   },
-  SET_CART_SIDEBAR_IS_OPEN(state, flag) {
-    state.cartSidebarOpen = flag
-  },
   SET_LANG(state, locale) {
     if (state.locales.includes(locale)) {
       state.locale = locale
@@ -39,6 +35,5 @@ export const getters = {
   getCart: (state) => state.cart,
   getPage: (state) => state.page,
   getUser: (state) => state.user,
-  getSessionContext: (state) => state.sessionContext,
-  getIsCartSidebarOpen: (state) => state.cartSidebarOpen,
+  getSessionContext: (state) => state.sessionContext
 }


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

part of #702 

create Atom SwButton to easily override theme buttons

<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
