### PR TITLE
fix: dropdown user icon

### DIFF
--- a/packages/default-theme/components/SwBottomNavigation.vue
+++ b/packages/default-theme/components/SwBottomNavigation.vue
@@ -34,20 +34,20 @@
         class="menu-button"
       >
         <template #icon>
-          <SfIcon icon="profile" size="20px" @click="userIconClick"/>
-          <SfSelect
-            class="menu-button__select"
-            v-if="isLoggedIn"
-          >
+          <SfIcon icon="profile" size="20px" @click="userIconClick" />
+          <SfSelect v-if="isLoggedIn" class="menu-button__select">
             <!-- TODO: change .native to @click after https://github.com/DivanteLtd/storefront-ui/issues/1097 -->
-            <SfSelectOption :value="getPageAccount" @click.native="goToMyAccount">
-                My account
+            <SfSelectOption
+              :value="getPageAccount"
+              @click.native="goToMyAccount"
+            >
+              My account
             </SfSelectOption>
             <!-- TODO: change .native to @click after https://github.com/DivanteLtd/storefront-ui/issues/1097 -->
             <SfSelectOption :value="'logout'">
-                <SwButton @click="logoutUser">
-                  Logout
-                </SwButton>
+              <SwButton class="sf-button--full-width" @click="logoutUser">
+                Logout
+              </SwButton>
             </SfSelectOption>
           </SfSelect>
         </template>
@@ -63,12 +63,12 @@
         :is-floating="true"
       >
         <template #icon>
-          <SfCircleIcon 
-            aria-label="Go to Cart" 
-            @click="toggleSidebar" 
-            icon="empty_cart" 
+          <SfCircleIcon
+            aria-label="Go to Cart"
+            icon="empty_cart"
             :has-badge="count > 0"
             :badge-label="count.toString()"
+            @click="toggleSidebar"
           />
         </template>
       </SfBottomNavigationItem>
@@ -82,7 +82,7 @@ import {
   SfCircleIcon,
   SfIcon,
   SfSelect,
-  SfProductOption
+  SfProductOption,
 } from '@storefront-ui/vue'
 import {
   useCartSidebar,
@@ -91,10 +91,10 @@ import {
   useCart,
   useUserLoginModal,
 } from '@shopware-pwa/composables'
-import { PAGE_ACCOUNT, PAGE_LOGIN } from '../helpers/pages'
 import SwCurrency from '@shopware-pwa/default-theme/components/SwCurrency'
 import { onMounted } from '@vue/composition-api'
 import SwButton from '@shopware-pwa/default-theme/components/atoms/SwButton'
+import { PAGE_ACCOUNT, PAGE_LOGIN } from '../helpers/pages'
 
 export default {
   name: 'SwBottomNavigation',
@@ -105,7 +105,7 @@ export default {
     SfSelect,
     SfProductOption,
     SwCurrency,
-    SwButton
+    SwButton,
   },
   data() {
     return {
@@ -134,24 +134,23 @@ export default {
       isSidebarOpen,
       toggleSidebar,
       toggleModal,
-      count
+      count,
     }
+  },
+  computed: {
+    getPageAccount() {
+      return PAGE_ACCOUNT
+    },
   },
   watch: {
     currentRoute(nextRoute) {
       this.$router.push(this.$i18n.path(nextRoute.routeLabel))
     },
   },
-  computed: {
-    getPageAccount() {
-      return PAGE_ACCOUNT
-    }
-  },
   methods: {
     userIconClick() {
       if (this.isLoggedIn) {
         this.$router.push(this.$i18n.path(PAGE_ACCOUNT))
-        return
       }
     },
     goToMyAccount() {
@@ -160,7 +159,7 @@ export default {
     async logoutUser() {
       await this.logout()
       this.$router.push(this.$i18n.path('/'))
-    }
+    },
   },
 }
 </script>

--- a/packages/default-theme/components/SwBottomNavigation.vue
+++ b/packages/default-theme/components/SwBottomNavigation.vue
@@ -151,7 +151,7 @@ export default {
     userIconClick() {
       if (this.isLoggedIn) {
         this.$router.push(this.$i18n.path(PAGE_ACCOUNT))
-      }
+      } else this.toggleModal()
     },
     goToMyAccount() {
       this.$router.push(this.$i18n.path(PAGE_ACCOUNT))

--- a/packages/default-theme/components/SwTopNavigation.vue
+++ b/packages/default-theme/components/SwTopNavigation.vue
@@ -78,6 +78,7 @@
                   <nuxt-link
                     class="sf-button sf-button--full-width sf-button--underlined color-primary"
                     :to="getPageAccount"
+                    @click.native="isDropdownOpen = false"
                   >
                     My account
                   </nuxt-link>
@@ -217,6 +218,7 @@ export default {
     },
     async logoutUser() {
       await this.logout()
+      this.isDropdownOpen = false
       this.$router.push(this.$i18n.path('/'))
     },
   },

--- a/packages/default-theme/components/SwTopNavigation.vue
+++ b/packages/default-theme/components/SwTopNavigation.vue
@@ -279,6 +279,7 @@ export default {
   }
   .dropdown {
     --dropdown-width: auto;
+    --dropdown-transform: translate(-10%, 100%);
     &__item {
       &:hover {
         color: var(--c-link-hover);


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #769




<!-- Paste here screenshot if there are visual changes -->


- [x] clicking outside 
- [x] center dropdown 
![Zrzut ekranu 2020-05-27 o 14 10 17](https://user-images.githubusercontent.com/12138170/83017852-abcfa380-a024-11ea-82c3-a74106f60d90.png)
- [x] click logout on mobile work
- [x] logout button styles
![Zrzut ekranu 2020-05-27 o 14 18 24](https://user-images.githubusercontent.com/12138170/83018084-fcdf9780-a024-11ea-9bae-1855d2a01631.png)
- [x] open log in modal on mobile
### Checklist

- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
