### PR TITLE
fix: currency sign and price should be in one line

### DIFF
--- a/packages/default-theme/components/SwProductCard.vue
+++ b/packages/default-theme/components/SwProductCard.vue
@@ -92,3 +92,11 @@ export default {
   },
 }
 </script>
+<style lang="scss" scoped>
+@import '@/assets/scss/variables';
+.sw-product-card {
+  ::v-deep .sf-price {
+    flex-wrap: wrap;
+  }
+}
+</style>


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
#816



<!-- Paste here screenshot if there are visual changes -->
![Zrzut ekranu 2020-05-28 o 14 58 07](https://user-images.githubusercontent.com/12138170/83144537-c6bd1900-a0f3-11ea-84ee-55bfd3a1fef0.png)





### Checklist

- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
