### PR TITLE
fix: pictures on home page have not equal

### DIFF
--- a/packages/default-theme/cms/blocks/CmsBlockImageSimpleGrid.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockImageSimpleGrid.vue
@@ -54,28 +54,23 @@ export default {
 ::v-deep.sw-image-simple-grid {
   display: flex;
   flex-direction: column;
-
-  &__left-images {
-    margin: var(--spacer-sm);
-  }
-
   &__image {
-    margin: var(--spacer-sm);
     img {
       height: 340px;
       object-fit: cover;
     }
   }
   @include for-desktop {
+    flex-direction: row;
     justify-content: space-around;
     align-items: center;
-    flex-direction: row;
-
     &__left-images {
       display: flex;
       flex-direction: column;
+      margin: var(--spacer-sm);
     }
     &__image {
+      margin: var(--spacer-sm);
       &--right {
         img {
           height: 712px;


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #821



<!-- Paste here screenshot if there are visual changes -->
![Zrzut ekranu 2020-05-28 o 17 01 10](https://user-images.githubusercontent.com/12138170/83158388-03454080-a105-11ea-9b4f-cc1fa0f8e7b8.png)





### Checklist

- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
