### PR TITLE
fix: z-indexes in sidebars and login modal

### DIFF
--- a/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
+++ b/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
@@ -60,6 +60,7 @@
       <SfSidebar
         title="Filters"
         :visible="isFilterSidebarOpen"
+        class="filters-sidebar"
         @close="isFilterSidebarOpen = false"
       >
         <div class="filters">
@@ -368,5 +369,9 @@ export default {
     margin-top: 10px;
     background-color: var(--c-light);
   }
+}
+.filters-sidebar {
+  --sidebar-z-index: 4;
+  --overlay-z-index: 4;
 }
 </style>

--- a/packages/default-theme/components/SwCart.vue
+++ b/packages/default-theme/components/SwCart.vue
@@ -139,6 +139,7 @@ export default {
 
 .sw-side-cart {
   --sidebar-z-index: 4;
+  --overlay-z-index: 4;
   & > * {
     --sidebar-content-padding: 0 var(--spacer-xs) var(--spacer-xs)
       var(--spacer-xs);

--- a/packages/default-theme/components/modals/SwLoginModal.vue
+++ b/packages/default-theme/components/modals/SwLoginModal.vue
@@ -133,6 +133,8 @@ export default {
 
 #sw-login-modal {
   box-sizing: border-box;
+  --overlay-z-index: 4;
+  --modal-index: 4;
   @include for-desktop {
     & > * {
       --modal-width: unset;


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
fix z-index in SfSidebra elements (on Filters and Cart)

<!-- Paste here screenshot if there are visual changes -->
after
![Zrzut ekranu 2020-05-29 o 07 33 59](https://user-images.githubusercontent.com/12138170/83225152-6ffd2100-a17f-11ea-9a7a-92f5587dac5e.png)
![Zrzut ekranu 2020-05-29 o 07 34 08](https://user-images.githubusercontent.com/12138170/83225157-725f7b00-a17f-11ea-84a1-2ef07f4b9086.png)
<img width="1151" alt="Zrzut ekranu 2020-05-29 o 10 57 28" src="https://user-images.githubusercontent.com/12138170/83241504-3803d700-a19b-11ea-82f3-c26f43393937.png">

before
![Zrzut ekranu 2020-05-29 o 07 39 39](https://user-images.githubusercontent.com/12138170/83225234-958a2a80-a17f-11ea-96b7-41b65a8a3950.png)
![Zrzut ekranu 2020-05-29 o 07 40 12](https://user-images.githubusercontent.com/12138170/83225254-a5a20a00-a17f-11ea-9e44-f202c48c9d74.png)
![Uploading Zrzut ekranu 2020-05-29 o 10.57.58.png…]()




### Checklist

- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
