### PR TITLE
docs: additional troubleshooting advise

### DIFF
--- a/docs/guide/TROUBLESHOOTING.md
+++ b/docs/guide/TROUBLESHOOTING.md
@@ -23,6 +23,8 @@ sidebar: auto
 
 - In your Shopware platform: Assign the categories and the products to the right Sales Channel, related to the `shopwareAccessToken` you have set in _shopware-pwa.config.js_.
 
+- It might be, that your local PWA version is out of date. Try updating it using `npm -g install @shopware-pwa/cli@canary --force` and re-run `shopware-pwa init` selecting the `canary` version, if you're unsure about the correct version to use. 
+
 ---
 
 `*` - if you are using your self-hosted Shopware instance


### PR DESCRIPTION
## Changes
Added troubleshooting advice for outdated cli version leading to incompatible theme version.

It happens when PWA and API version are out of sync and an empty product listing showed up even though products are delivered through the API.

### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
