### PR TITLE
feat(plugins): context for plugin slots  🚀 

### DIFF
--- a/packages/cli/src/templates/plugins/SwPluginSlot.vue
+++ b/packages/cli/src/templates/plugins/SwPluginSlot.vue
@@ -1,5 +1,7 @@
 <template>
-  <component :is="getComponent" :name="name"> <slot /> </component>
+  <component :is="getComponent" :name="name" :slotContext="slotContext">
+    <slot />
+  </component>
 </template>
 <script>
 import Vue from "vue"
@@ -26,6 +28,10 @@ export default {
       type: String,
       default: "",
     },
+    slotContext: {
+      type: Object,
+      default: null
+    }
   },
   setup() {
     const { showPluginSlots } = usePlugins();

--- a/packages/default-theme/components/SwProductDetails.vue
+++ b/packages/default-theme/components/SwProductDetails.vue
@@ -11,7 +11,7 @@
         :tier-prices="getTierPrices"
       />
     </div>
-    <SwPluginSlot name="product-page-description">
+    <SwPluginSlot name="product-page-description" :slotContext="product">
       <p
         class="product-details__description desktop-only"
         v-html="description"
@@ -50,7 +50,10 @@
         class="product-details__add-to-cart"
         @click="addToCart"
       />
-      <SwPluginSlot name="product-page-add-to-cart-button-after" />
+      <SwPluginSlot
+        name="product-page-add-to-cart-button-after"
+        :slotContext="product"
+      />
       <div class="product-details__action desktop-only">
         <SwButton class="sf-button--text product-details__action-button"
           >Save for later</SwButton

--- a/packages/default-theme/components/views/ProductView.vue
+++ b/packages/default-theme/components/views/ProductView.vue
@@ -1,13 +1,13 @@
 <template>
   <div v-if="product" id="product">
-    <SwPluginSlot name="product-page-details-before" />
+    <SwPluginSlot name="product-page-details-before" :slotContext="product" />
     <div class="product">
       <SwProductGallery :product="product" class="product__gallery" />
       <div class="product__description">
         <SwProductDetails :product="product" :page="page" />
       </div>
     </div>
-    <SwPluginSlot name="product-page-details-after" />
+    <SwPluginSlot name="product-page-details-after" :slotContext="product" />
     <div class="products__recomendations">
       <div class="products-recomendations__section">
         <SwProductCarousel />

--- a/packages/default-theme/layouts/default.vue
+++ b/packages/default-theme/layouts/default.vue
@@ -3,7 +3,7 @@
     <SwPluginSlot name="page-top" />
     <SwHeader />
     <SwPluginSlot name="top-header-after" />
-    <SwPluginSlot name="breadcrumbs">
+    <SwPluginSlot name="breadcrumbs" :slotContext="getBreadcrumbs" >
       <SfBreadcrumbs
         v-show="getBreadcrumbs.length > 0"
         :breadcrumbs="getBreadcrumbs"


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

Introducing context for plugin slots
- slot with context can have passed context, example
  - `<SwPluginSlot name="product-page-description" :slotContext="product">`
  - `<SwPluginSlot name="breadcrumbs" :slotContext="getBreadcrumbs" >`

Then in plugin all you need to do is to add props to have expected context:
```vue
<template>
  <div class="my-local-plugin">
    <h3>Hello from your local plugin!</h3>
    <div v-if="slotContext">
      <span> {{ slotContext.name }} </span>
      <span> {{ slotContext.id }} </span>
    </div>
  </div>
</template>
<script>
export default {
  name: 'MyLocalPlugin',
  props: {
    slotContext: {
      type: Object,
      default: null
    }
  },
  data() {
    return {}
  }
}
</script>
```


<!-- Paste here screenshot if there are visual changes -->

result:
![image](https://user-images.githubusercontent.com/13100280/83490226-ee273380-a4af-11ea-94ff-84eff302e2d1.png)





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
