### PR TITLE
fix: product carousel on mobile in the horizontal position

### DIFF
--- a/packages/default-theme/cms/elements/CmsElementProductSlider.vue
+++ b/packages/default-theme/cms/elements/CmsElementProductSlider.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="cms-element-product-slider">
     <SfSection :title-heading="title" class="section">
-      <SfCarousel class="product-carousel">
+      <SfCarousel class="product-carousel" :settings="options">
         <SfCarouselItem v-for="product in products" :key="product.id">
           <SwProductCard :product="product" class="product-carousel__product" />
         </SfCarouselItem>
@@ -38,6 +38,24 @@ export default {
         ? this.content.config.title.value
         : ""
     },
+  },
+  data(){
+    return {
+      options: {
+        breakpoints: {
+          480: {
+            perView: 2,
+            peek: {
+              before: 0,
+              after: 50,
+            },
+          },
+          1023: {
+            perView: 4,
+          },
+        },
+      }
+    }
   },
 }
 </script>

--- a/packages/default-theme/cms/elements/CmsElementProductSlider.vue
+++ b/packages/default-theme/cms/elements/CmsElementProductSlider.vue
@@ -3,7 +3,7 @@
     <SfSection :title-heading="title" class="section">
       <SfCarousel class="product-carousel">
         <SfCarouselItem v-for="product in products" :key="product.id">
-          <SwProductCard :product="product" />
+          <SwProductCard :product="product" class="product-carousel__product" />
         </SfCarouselItem>
       </SfCarousel>
     </SfSection>
@@ -47,5 +47,12 @@ export default {
 
 .cms-element-product-slider {
   width: 100%;
+}
+.product-carousel {
+  &__product {
+    @include for-mobile {
+      max-width: unset;
+    }
+  }
 }
 </style>

--- a/packages/default-theme/components/SwProductCarousel.vue
+++ b/packages/default-theme/components/SwProductCarousel.vue
@@ -5,9 +5,9 @@
       class="section"
       title-heading="You may also like"
     >
-      <SfCarousel class="product-carousel">
+      <SfCarousel class="product-carousel" :settings="options">
         <SfCarouselItem v-for="product in products" :key="product.id">
-          <SwProductCard :product="product" />
+          <SwProductCard :product="product" class="product-carousel__product" />
         </SfCarouselItem>
       </SfCarousel>
     </SfSection>
@@ -31,6 +31,20 @@ export default {
   data() {
     return {
       products: {},
+      options: {
+        breakpoints: {
+          480: {
+            perView: 2,
+            peek: {
+              before: 0,
+              after: 50,
+            },
+          },
+          1023: {
+            perView: 4,
+          },
+        },
+      }
     }
   },
   async mounted() {
@@ -69,6 +83,11 @@ export default {
     margin: var(--spacer-base) 0;
     --carousel-padding: var(--spacer-base);
     --carousel-max-width: calc(100% - 13.5rem);
+  }
+  &__product {
+    @include for-mobile {
+      max-width: unset;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #783



<!-- Paste here screenshot if there are visual changes -->
![Zrzut ekranu 2020-06-2 o 10 01 07](https://user-images.githubusercontent.com/12138170/83495464-04d18880-a4b8-11ea-9552-0703da134e06.png)
![Zrzut ekranu 2020-06-2 o 10 01 17](https://user-images.githubusercontent.com/12138170/83495470-07cc7900-a4b8-11ea-9f67-1eb72d3c45fa.png)





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
