### PR TITLE
fix(default-theme): build the right storefront URL during registration

### DIFF
--- a/packages/default-theme/components/SwRegister.vue
+++ b/packages/default-theme/components/SwRegister.vue
@@ -178,7 +178,7 @@ export default {
         email: this.email,
         password: this.password,
         salutationId: this.salutation.id,
-        storefrontUrl: window?.location?.origin,
+        storefrontUrl: window && window.location && `${window.location.protocol}//${window.location.hostname}`,
         billingAddress: {
           firstName: this.firstName,
           salutationId: this.salutation.id,


### PR DESCRIPTION
## Changes
closes #859 
- gets rid of the port, leave the protocol and domain only as storefrontUrl



<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
