### PR TITLE
fix(default-theme): my account order list dates #792

### DIFF
--- a/packages/default-theme/helpers/index.js
+++ b/packages/default-theme/helpers/index.js
@@ -33,7 +33,7 @@ export const getSortingLabel = (sorting) => {
   return `${sorting.field} ${label}`
 }
 
-export const formatDate = (date, format = `DD-MM-YYYY H:m:s`) =>
+export const formatDate = (date, format = `DD-MM-YYYY HH:mm:ss`) =>
   dayjs(date).format(format)
 
 export const getSearchPageUrl = (searchTerm) =>

--- a/packages/shopware-6-client/__tests__/services/CustomerService/getCustomerOrders.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/CustomerService/getCustomerOrders.spec.ts
@@ -43,7 +43,9 @@ describe("CustomerService - getCustomerOrders", () => {
     });
     const result = await getCustomerOrders();
     expect(mockedGet).toBeCalledTimes(1);
-    expect(mockedGet).toBeCalledWith(getCustomerOrderEndpoint());
+    expect(mockedGet).toBeCalledWith(
+      `${getCustomerOrderEndpoint()}?sort=-createdAt`
+    );
     expect(result).toMatchObject([
       {
         orderNumber: "1234",

--- a/packages/shopware-6-client/src/services/customerService.ts
+++ b/packages/shopware-6-client/src/services/customerService.ts
@@ -121,7 +121,9 @@ export async function getCustomerAddresses(
 export async function getCustomerOrders(
   contextInstance: ShopwareApiInstance = defaultInstance
 ): Promise<Order[]> {
-  const resp = await contextInstance.invoke.get(getCustomerOrderEndpoint());
+  const resp = await contextInstance.invoke.get(
+    `${getCustomerOrderEndpoint()}?sort=-createdAt`
+  );
   return resp.data.orders?.elements || [];
 }
 


### PR DESCRIPTION
## Changes
closes #792 

- `number of orders` indicator has been fixed in other PR.




<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
