### PR TITLE
chore: add missing core-js nuxt dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "brotli": "^1.3.2",
     "chalk": "^4.0.0",
     "conventional-changelog-cli": "^2.0.31",
+    "core-js": "^3.6.5",
     "coveralls": "^3.0.13",
     "cypress": "^4.4.1",
     "enquirer": "^2.3.5",


### PR DESCRIPTION
## Changes
fixes fatat Nuxt build error:
```
Module not found: Error: Can't resolve 'core-js/modules/*
```


<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
