### PR TITLE
chore(cli): disable telemetry and set nuxt target

### DIFF
--- a/packages/cli/src/extensions/nuxt-extension.ts
+++ b/packages/cli/src/extensions/nuxt-extension.ts
@@ -30,6 +30,8 @@ module.exports = (toolbox: GluegunToolbox) => {
       test: "jest",
       mode: "universal",
       devTools: [],
+      target: "server",
+      telemetry: false,
     };
     if (!isNuxtGenerated) {
       const nuxtGenerate = `npx --ignore-existing create-nuxt-app --answers "${JSON.stringify(


### PR DESCRIPTION
## Changes
fixes an issue during project init on shopware-pwa/cli init
disables telemetry sync on nuxt build


<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
