### PR TITLE
fix(cli): fix breaking changes after Nuxt 2.13 released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.1.1](https://github.com/DivanteLtd/shopware-pwa/compare/v0.1.0...v0.1.1) (2020-06-22)
+
+
+### Bug Fixes
+
+* **cli:** fix breaking changes after Nuxt 2.13 released ([51629fa](https://github.com/DivanteLtd/shopware-pwa/commit/51629fad22686a659a01925b06747c4dc86f3322))
+
+
+
 # [0.1.0](https://github.com/DivanteLtd/shopware-pwa/compare/v0.1.0-alpha.9...v0.1.0) (2020-05-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopware-pwa",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-pwa/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shopware PWA CLI",
   "types": "build/types/types.d.ts",
   "bin": {
@@ -30,7 +30,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@shopware-pwa/shopware-6-client": "0.1.0",
+    "@shopware-pwa/shopware-6-client": "0.1.1",
     "gluegun": "^4.3.1",
     "lodash": "^4.17.15",
     "request": "^2.88.2",

--- a/packages/cli/src/extensions/nuxt-extension.ts
+++ b/packages/cli/src/extensions/nuxt-extension.ts
@@ -32,7 +32,7 @@ module.exports = (toolbox: GluegunToolbox) => {
       devTools: [],
     };
     if (!isNuxtGenerated) {
-      const nuxtGenerate = `npx --ignore-existing create-nuxt-app --answers "${JSON.stringify(
+      const nuxtGenerate = `npx --ignore-existing create-nuxt-app@2.15.0 --answers "${JSON.stringify(
         nuxtAnswers
       ).replace(/"/g, '\\"')}"`;
       await run(nuxtGenerate);
@@ -152,6 +152,19 @@ module.exports = (toolbox: GluegunToolbox) => {
     );
     if (!swPluginsIgnoreExist) {
       await toolbox.patching.append(".gitignore", ".shopware-pwa\n");
+    }
+
+    // Add telemetry flag
+    const configTelemetryFlag = await toolbox.patching.exists(
+      "nuxt.config.js",
+      `telemetry:`
+    );
+    if (!configTelemetryFlag) {
+      await toolbox.patching.patch("nuxt.config.js", {
+        insert: `
+  telemetry: false,`,
+        after: "mode: 'universal',",
+      });
     }
   };
 

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-pwa/commons",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "@shopware-pwa/commons",
   "license": "MIT",
   "files": [

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-pwa/composables",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "@shopware-pwa/composables",
   "main": "dist/composables.cjs.js",
   "module": "dist/composables.esm-bundler.js",
@@ -25,7 +25,7 @@
   "dependencies": {
     "axios": "^0.19.2",
     "@vue/composition-api": "^0.5.0",
-    "@shopware-pwa/shopware-6-client": "0.1.0",
+    "@shopware-pwa/shopware-6-client": "0.1.1",
     "cookie-universal": "^2.1.3",
     "query-string": "^6.12.1",
     "vue": "^2.6.11"

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-pwa/default-theme",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shopware PWA theme",
   "author": "patzick",
   "scripts": {

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@storefront-ui/vue": "0.7.17",
+    "core-js": "^3.6.5",
     "currency.js": "^1.2.2",
     "dayjs": "^1.8.25",
     "html-to-vue": "^1.2.0",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-pwa/helpers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "@shopware-pwa/helpers",
   "main": "dist/helpers.cjs.js",
   "module": "dist/helpers.esm-bundler.js",

--- a/packages/nuxt-module/package.json
+++ b/packages/nuxt-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-pwa/nuxt-module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "@shopware-pwa/nuxt-module",
   "main": "dist/nuxt-module.cjs.js",
   "module": "dist/nuxt-module.esm-bundler.js",

--- a/packages/shopware-6-client/package.json
+++ b/packages/shopware-6-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-pwa/shopware-6-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Rest API client for Shopware 6.",
   "main": "dist/shopware-6-client.cjs.js",
   "module": "dist/shopware-6-client.esm-bundler.js",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -8,7 +8,9 @@ const { prompt } = require("enquirer");
 const execa = require("execa");
 
 const isCanaryRelease = args.canary;
-const preId = args.preid || semver.prerelease(currentVersion)[0] || "alpha";
+const semverPrereleaseTag =
+  semver.prerelease(currentVersion) && semver.prerelease(currentVersion)[0];
+const preId = args.preid || semverPrereleaseTag || "alpha";
 const isDryRun = args.dry;
 const skipTests = args.skipTests;
 const skipBuild = args.skipBuild;


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

* `create-nuxt-app` cannot handle default answers, we need to use versioned release for now
* added `core-js` to theme dependencies, as it showed errors after Nuxt 2.13 release

<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
