### PR TITLE
fix: load the main navigation elements - watch issue

### DIFF
--- a/packages/default-theme/components/SwTopNavigation.vue
+++ b/packages/default-theme/components/SwTopNavigation.vue
@@ -54,14 +54,19 @@ export default {
       switchOverlay(!!currentCategoryName.value)
     }
 
-    onMounted(() => {
-      watch(currentLocale, async () => {
+    onMounted(async () => {
+      await watch(currentLocale, async () => {
         try {
           await fetchNavigationElements(3)
         } catch (e) {
           console.error("[SwTopNavigation]", e)
         }
       })
+
+      // fixes a watch issue - fetch the elements if watch wasn't fired
+      if (Array.isArray(navigationElements) && !navigationElements.length) {
+        fetchNavigationElements(3)
+      }
     })
 
     return {


### PR DESCRIPTION
## Changes
invoke the navi elements loading again if the navigation array is empty.
watch function from composition api does not trigger the navigation fetching for some reason. 




<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
