### PR TITLE
chore(nuxt): force different build filenames

### DIFF
--- a/packages/default-theme/nuxt.config.js
+++ b/packages/default-theme/nuxt.config.js
@@ -102,5 +102,8 @@ export default {
         config.optimization.splitChunks.cacheGroups.commons.minChunks = 2
       }
     },
+    filenames: {
+      chunk: ({ isDev }) => (isDev ? "[name].js" : "[id].[contenthash].js"),
+    },
   },
 }


### PR DESCRIPTION
## Changes
fixes the 404 while loading commons scripts starting with "." (dot). 



<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
