### PR TITLE
chore(nuxt-module): set chunk names for deployment

### DIFF
--- a/packages/nuxt-module/__tests__/module.spec.ts
+++ b/packages/nuxt-module/__tests__/module.spec.ts
@@ -254,4 +254,15 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
   it("interfaces should return default empty object", () => {
     expect(InterfacesDefault).toEqual({});
   });
+
+  it("should change build chunk names", () => {
+    runModule(moduleObject, {});
+    expect(moduleObject.options.build.filenames.chunk).toBeTruthy();
+    expect(
+      moduleObject.options.build.filenames.chunk({ isDev: false })
+    ).toEqual("[id].[contenthash].js");
+    expect(moduleObject.options.build.filenames.chunk({ isDev: true })).toEqual(
+      "[name].js"
+    );
+  });
 });

--- a/packages/nuxt-module/src/interfaces.ts
+++ b/packages/nuxt-module/src/interfaces.ts
@@ -14,6 +14,14 @@ export interface NuxtModuleOptions extends ModuleThis {
       babel?: {
         presets?: (params: { isServer: boolean }) => void;
       };
+      filenames?: {
+        app?: ({ isDev }: { isDev: boolean }) => string;
+        chunk?: ({ isDev }: { isDev: boolean }) => string;
+        css?: ({ isDev }: { isDev: boolean }) => string;
+        img?: ({ isDev }: { isDev: boolean }) => string;
+        font?: ({ isDev }: { isDev: boolean }) => string;
+        video?: ({ isDev }: { isDev: boolean }) => string;
+      };
     };
   };
   addLayout: (options: { src: string }, templateName: string) => void;

--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -135,6 +135,11 @@ export function runModule(moduleObject: NuxtModuleOptions, moduleOptions: {}) {
     ];
   };
 
+  moduleObject.options.build.filenames =
+    moduleObject.options.build.filenames || {};
+  moduleObject.options.build.filenames.chunk = ({ isDev }) =>
+    isDev ? "[name].js" : "[id].[contenthash].js";
+
   const corePackages: string[] = [
     "@shopware-pwa/composables",
     "@shopware-pwa/helpers",


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

inspired by #926, changing the config in nuxt-module, and fixing the problem with deploying files, which names start with a dot.



<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
