### PR TITLE
fix(default-theme): added icon to more categories

### DIFF
--- a/packages/default-theme/components/SwTopNavigationShowMore.vue
+++ b/packages/default-theme/components/SwTopNavigationShowMore.vue
@@ -1,3 +1,27 @@
 <template>
-  <span class="sf-header__link">{{ $t("More") }}</span>
+  <div>
+    <span class="sf-header__link">{{ $t("More") }}</span>
+    <SfIcon
+      icon="chevron_down"
+      class="sf-chevron_down"
+      size="21px"
+      view-box="0 0 24 12"
+    />
+  </div>
 </template>
+
+<script>
+import { SfIcon } from "@storefront-ui/vue"
+
+export default {
+  components: {
+    SfIcon,
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.sf-header__link {
+  margin-right: 8px;
+}
+</style>


### PR DESCRIPTION
## Changes
Added chevron down icon. to the more categories section in navigation.
closes #913 

![Zrzut ekranu 2020-07-7 o 14 32 30](https://user-images.githubusercontent.com/4071200/86781845-b2f3c380-c05e-11ea-8199-1cff2f35dc09.png)






### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
