### PR TITLE
feat(default-theme): boxed-mode max width can now be changed

### DIFF
--- a/packages/default-theme/assets/scss/variables.scss
+++ b/packages/default-theme/assets/scss/variables.scss
@@ -1,12 +1,11 @@
 @import "~@storefront-ui/shared/styles/variables";
 
-// Global variables for theme
-
-// #__nuxt {
-//   --c-primary: #5ece7b;
-// }
-
 $tablet: 768px;
+
+// Global variables for theme
+#__nuxt {
+  --boxed-mode-max-width: 1366px;
+}
 
 @mixin for-tablet {
   @media screen and (min-width: $tablet) {
@@ -16,7 +15,7 @@ $tablet: 768px;
 
 @mixin sizing-mode-boxed {
   @include for-desktop {
-    max-width: 1320px;
+    max-width: var(--boxed-mode-max-width);
     margin: 0 auto;
   }
 }

--- a/packages/default-theme/cms/settings.scss
+++ b/packages/default-theme/cms/settings.scss
@@ -1,8 +1,2 @@
 @import '~@storefront-ui/vue/styles.scss';
-
-@mixin sizing-mode-boxed {
-  @include for-desktop {
-    max-width: 1320px;
-    margin: 0 auto;
-  }
-}
+@import '@/assets/scss/variables';


### PR DESCRIPTION

## Changes
Boxed mode blocks have now dynamic max-width css variable set in variables.scss






### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
