### PR TITLE
fix(nuxt-module): correct aliases to support windows 10 component override

### DIFF
--- a/packages/cli/src/commands/override.ts
+++ b/packages/cli/src/commands/override.ts
@@ -31,7 +31,8 @@ module.exports = {
   description:
     "Allows you to override theme component. Component will appear in project ready to be edited.",
   run: async (toolbox: GluegunToolbox) => {
-    const directoryPath = `${toolbox.defaultThemeLocation}/components/`;
+    const path = require("path");
+    const directoryPath = path.join(toolbox.defaultThemeLocation, "components");
 
     const componentsFullPaths = getAllFiles(directoryPath);
     const themeComponents = componentsFullPaths.map((path) =>
@@ -48,8 +49,8 @@ module.exports = {
 
     const answers = await toolbox.prompt.ask([componentToOverrideQuestion]);
 
-    const copyFrom = `${directoryPath}${answers.componentToOverride}`;
-    const copyTo = `components/${answers.componentToOverride}`;
+    const copyFrom = path.join(directoryPath, answers.componentToOverride);
+    const copyTo = path.join("components", answers.componentToOverride);
 
     try {
       await toolbox.filesystem.copyAsync(copyFrom, copyTo);

--- a/packages/nuxt-module/src/components.ts
+++ b/packages/nuxt-module/src/components.ts
@@ -28,6 +28,7 @@ export function extendComponents(moduleObject: NuxtModuleOptions) {
               "@shopware-pwa/default-theme"
             )
             .replace(".vue", "")
+            .replace(/\\/g, "/") // windows fix
         ] = themeFile;
       });
       // lastThemeFiles = themeFiles;

--- a/packages/nuxt-module/src/layouts.ts
+++ b/packages/nuxt-module/src/layouts.ts
@@ -7,7 +7,10 @@ export function addThemeLayouts(moduleObject: NuxtModuleOptions) {
   const layouts = getAllFiles(
     path.join(
       moduleObject.options.rootDir,
-      "node_modules/@shopware-pwa/default-theme/layouts"
+      "node_modules",
+      "@shopware-pwa",
+      "default-theme",
+      "layouts"
     )
   );
   layouts.forEach((layout) => {

--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -102,7 +102,8 @@ export function runModule(moduleObject: NuxtModuleOptions, moduleOptions: {}) {
   moduleObject.extendBuild((config: WebpackConfig, ctx: WebpackContext) => {
     const swPluginsDirectory = path.join(
       moduleObject.options.rootDir,
-      ".shopware-pwa/sw-plugins"
+      ".shopware-pwa",
+      "sw-plugins"
     );
     config.resolve.alias["sw-plugins"] = swPluginsDirectory;
     if (ctx.isClient && !ctx.isDev) {


### PR DESCRIPTION

## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #973 

Fixes components override on Windows 10.

<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
