### PR TITLE
feat(default-theme): bottom navigation always visible on mobile

### DIFF
--- a/packages/default-theme/assets/scss/variables.scss
+++ b/packages/default-theme/assets/scss/variables.scss
@@ -5,6 +5,7 @@ $tablet: 768px;
 // Global variables for theme
 #__nuxt {
   --boxed-mode-max-width: 1366px;
+  --bottom-navigation-height: 3.35rem;
 }
 
 @mixin for-tablet {

--- a/packages/default-theme/components/SwBottomNavigation.vue
+++ b/packages/default-theme/components/SwBottomNavigation.vue
@@ -67,22 +67,38 @@
           <SwCurrencySwitcher class="menu-button__currency" />
         </template>
       </SfBottomNavigationItem>
-      <SfBottomNavigationItem
-        icon="empty_cart"
-        label="Cart"
-        :is-floating="true"
-        data-cy="bottom-navigation-cart"
-        @click="toggleSidebar"
-      >
-        <template #icon>
-          <SfCircleIcon
-            aria-label="Go to Cart"
-            icon="empty_cart"
-            :has-badge="count > 0"
-            :badge-label="count.toString()"
-          />
-        </template>
-      </SfBottomNavigationItem>
+      <transition name="sf-collapse-bottom" mode="out-in">
+        <SfBottomNavigationItem
+          v-if="!isSidebarOpen"
+          key="openCart"
+          icon="empty_cart"
+          label="Cart"
+          class="sw-bottom-navigation__action-button"
+          :is-floating="true"
+          data-cy="bottom-navigation-cart"
+          @click="toggleSidebar(true)"
+        >
+          <template #icon>
+            <SfCircleIcon
+              aria-label="Go to Cart"
+              icon="empty_cart"
+              :has-badge="count > 0"
+              :badge-label="count.toString()"
+            />
+          </template>
+        </SfBottomNavigationItem>
+        <SfBottomNavigationItem
+          v-else
+          key="closeCart"
+          icon="cross"
+          label="Close"
+          class="sw-bottom-navigation__action-button"
+          :is-floating="true"
+          data-cy="bottom-navigation-close"
+          @click="toggleSidebar(false)"
+        >
+        </SfBottomNavigationItem>
+      </transition>
     </SfBottomNavigation>
   </div>
 </template>
@@ -176,8 +192,16 @@ export default {
   padding: 0 1rem;
 }
 
+::v-deep .sf-bottom-navigation-item .sf-circle-icon {
+  --button-size: 3.7rem;
+}
+
 .sw-bottom-navigation {
   align-items: center;
+
+  &__action-button {
+    min-width: 2rem;
+  }
 }
 .menu-button {
   position: relative;

--- a/packages/default-theme/components/SwBottomNavigation.vue
+++ b/packages/default-theme/components/SwBottomNavigation.vue
@@ -24,10 +24,13 @@
             style="width: 25px;"
             @click="toggleMobileNavigation"
           />
-          <SwBottomMenu
-            v-if="mobileNavIsActive"
-            @close="mobileNavIsActive = false"
-          />
+          <!-- TODO: remove transition after animation fix in SFUI -->
+          <transition name="sf-collapse-bottom" mode="out-in">
+            <SwBottomMenu
+              v-if="mobileNavIsActive"
+              @close="mobileNavIsActive = false"
+            />
+          </transition>
         </template>
       </SfBottomNavigationItem>
       <SfBottomNavigationItem

--- a/packages/default-theme/components/SwBottomNavigation.vue
+++ b/packages/default-theme/components/SwBottomNavigation.vue
@@ -72,6 +72,7 @@
         label="Cart"
         :is-floating="true"
         data-cy="bottom-navigation-cart"
+        @click="toggleSidebar"
       >
         <template #icon>
           <SfCircleIcon
@@ -79,7 +80,6 @@
             icon="empty_cart"
             :has-badge="count > 0"
             :badge-label="count.toString()"
-            @click="toggleSidebar"
           />
         </template>
       </SfBottomNavigationItem>

--- a/packages/default-theme/components/SwCart.vue
+++ b/packages/default-theme/components/SwCart.vue
@@ -5,7 +5,7 @@
       :visible="isSidebarOpen"
       :heading-title="$t('My cart')"
       class="sf-sidebar--right"
-      @close="toggleSidebar"
+      @close="toggleSidebar(false)"
     >
       <template v-if="count" #content-top>
         <SfProperty
@@ -139,16 +139,26 @@ export default {
 <style lang="scss" scoped>
 @import "@/assets/scss/variables";
 
+::v-deep .sf-sidebar__aside {
+  height: auto;
+}
+
 .sw-side-cart {
-  --sidebar-z-index: 4;
+  --sidebar-z-index: 1;
   --property-name-font-size: var(--font-lg);
   --property-value-font-size: var(--font-lg);
-  --overlay-z-index: 4;
+  --sidebar-bottom: var(--bottom-navigation-height, 0);
+  --overlay-z-index: 0;
+  --sidebar-bottom-padding: var(--spacer-sm) var(--spacer-sm) var(--spacer-xl);
+
   & > * {
     --sidebar-content-padding: 0 var(--spacer-xs) var(--spacer-xs)
       var(--spacer-xs);
   }
   @include for-desktop {
+    --sidebar-z-index: 4;
+    --overlay-z-index: 4;
+    --sidebar-bottom: 0;
     & > * {
       --sidebar-bottom-padding: var(--spacer-base);
       --sidebar-content-padding: 0 var(--spacer-base) var(--spacer-base)


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
closes #957 



<!-- Paste here screenshot if there are visual changes -->

![bottomnav](https://user-images.githubusercontent.com/13100280/89405496-f30c9b80-d71b-11ea-8815-c1b49af0599e.gif)




### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
