### PR TITLE
fix(composables): is in cart condition

### DIFF
--- a/packages/composables/__tests__/useAddToCart.spec.ts
+++ b/packages/composables/__tests__/useAddToCart.spec.ts
@@ -62,7 +62,7 @@ describe("Composables - useAddToCart", () => {
 
     describe("isInCart", () => {
       it("should show that product is in cart", () => {
-        cartItemsMock.value = [{ id: "qwe" }];
+        cartItemsMock.value = [{ referencedId: "qwe" }];
         const { isInCart } = useAddToCart(rootContextMock, {
           id: "qwe",
         } as any);
@@ -71,7 +71,7 @@ describe("Composables - useAddToCart", () => {
 
       it("should show that product is not cart", () => {
         stateCart.value = {
-          lineItems: [{ id: "qwert" }],
+          lineItems: [{ referencedId: "qwert" }],
         };
         const { isInCart } = useAddToCart(rootContextMock, {
           id: "qwe",

--- a/packages/composables/src/logic/useAddToCart.ts
+++ b/packages/composables/src/logic/useAddToCart.ts
@@ -82,8 +82,10 @@ export const useAddToCart = (
 
   const getStock = computed(() => product && product.stock);
 
-  const isInCart = computed((): boolean =>
-    cartItems.value.some((item: any) => item.id === product.id)
+  const isInCart = computed(
+    (): boolean =>
+      product &&
+      cartItems.value.some((item: any) => item.referencedId === product.id)
   );
 
   return {


### PR DESCRIPTION
## Changes
- prevents from seeing 500 while browsing product cards not contained in product listing (like custom cms block). 
- refactor of condition (aligned with 6.3 API change)

<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
