### PR TITLE
fix(api-client): add product to cart duplicate entries (#1051)

### DIFF
--- a/packages/shopware-6-client/__tests__/services/CartService/addProductToCart.spec.ts
+++ b/packages/shopware-6-client/__tests__/services/CartService/addProductToCart.spec.ts
@@ -52,6 +52,7 @@ describe("CartService - addProductToCart", () => {
           quantity: 1,
           referencedId: "044a190a54ab4f06803909c3ee8063ef",
           type: "product",
+          id: "044a190a54ab4f06803909c3ee8063ef",
         },
       ],
     });
@@ -77,6 +78,7 @@ describe("CartService - addProductToCart", () => {
             quantity: 1,
             referencedId: "someNonExistingProductId",
             type: "product",
+            id: "someNonExistingProductId",
           },
         ],
       }
@@ -96,6 +98,7 @@ describe("CartService - addProductToCart", () => {
           referencedId: "",
           type: "product",
           quantity: 2,
+          id: "",
         },
       ],
     });
@@ -117,6 +120,7 @@ describe("CartService - addProductToCart", () => {
           quantity: 1,
           referencedId: "qwe",
           type: "product",
+          id: "qwe",
         },
       ],
     });

--- a/packages/shopware-6-client/src/services/cartService.ts
+++ b/packages/shopware-6-client/src/services/cartService.ts
@@ -61,6 +61,7 @@ export async function addProductToCart(
           type: CartItemType.PRODUCT,
           referencedId: productId,
           quantity: qty,
+          id: productId,
         },
       ],
     }


### PR DESCRIPTION
## Changes

If you put the same product into the cart one by one, it creates new items (since there's no `id` passed to the endpoint).

That change was introduced in the the store-api.

**Before:**

![image](https://user-images.githubusercontent.com/7780750/91281209-1610f500-e788-11ea-83e6-b7caafaaee45.png)

**After:**

![image](https://user-images.githubusercontent.com/7780750/91281037-e95cdd80-e787-11ea-8e84-e79c982826ac.png)

### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
