### PR TITLE
fix(default-theme): fixed display text next to image in block

### DIFF
--- a/packages/default-theme/cms/blocks/CmsBlockTextOnImage.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockTextOnImage.vue
@@ -1,9 +1,12 @@
 <template>
   <article class="cms-block-text-on-image">
     <CmsGenericElement
-      v-if="getContent"
-      :content="getContent"
-      class="cms-block-text-on-image__content"
+      :content="getLeftContent"
+      class="cms-block-text-on-image__image"
+    />
+    <CmsGenericElement
+      :content="getRightContent"
+      class="cms-block-text-on-image__text"
     />
   </article>
 </template>
@@ -29,20 +32,53 @@ export default {
     getSlots() {
       return this.content.slots || []
     },
-    getContent() {
-      return this.getSlots.length && this.getSlots[0]
+
+    getLeftContent() {
+      return this.getSlots.find(({ slot }) => slot === "left")
+    },
+    getRightContent() {
+      return this.getSlots.find(({ slot }) => slot === "right")
     },
   },
 }
 </script>
 
 <style lang="scss" scoped>
-.cms-block-text-on-image {
-  background-position: center;
-  background-size: cover;
+@import "@/assets/scss/variables";
 
-  &__content {
-    padding: var(--spacer-2xl) var(--spacer-xl);
+.cms-block-text-on-image {
+  display: flex;
+  flex-direction: column;
+  margin-right: 0;
+  margin-left: 0;
+
+  &__image,
+  &__text {
+    margin: var(--spacer-sm);
+    flex: 1;
+    & img {
+      height: 340px;
+      object-fit: cover;
+      width: 100%;
+    }
+  }
+
+  @include for-desktop {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-around;
+
+    .cms-block-text-on-image__image {
+      margin-bottom: 0;
+      margin-right: var(--spacer-sm);
+      margin-top: 0;
+    }
+
+    .cms-block-text-on-image__text {
+      margin-bottom: 0;
+      margin-left: var(--spacer-sm);
+      margin-top: 0;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Changes
closes #967 

The component now gets the value of image & text and display it next to each other.

Desktop:
![Screenshot from 2020-08-27 12-25-32](https://user-images.githubusercontent.com/4071200/91433268-56917100-e863-11ea-9ca0-cfe34a943163.png)


Mobile:
![Screenshot from 2020-08-27 12-24-32](https://user-images.githubusercontent.com/4071200/91433282-5a24f800-e863-11ea-9fc1-9ab857da8995.png)



<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
