### PR TITLE
feat(default-theme): created and styled error list component

### DIFF
--- a/packages/default-theme/cms/elements/CmsElementContactForm.vue
+++ b/packages/default-theme/cms/elements/CmsElementContactForm.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <form
+      v-if="!formSent"
       action=""
       class="cms-element-contact-form"
       @submit.prevent="submit"
-      v-if="!formSent"
     >
       <SfSelect
         v-if="getMappedSalutations && getMappedSalutations.length > 0"
@@ -110,7 +110,7 @@
         />
       </div>
 
-      <SfAlert v-if="errorMessage" :message="errorMessage" type="danger" />
+      <SwErrorsList :list="errorMessage" />
 
       <SwButton class="send button">
         {{ $t("send") }}
@@ -132,7 +132,6 @@ import {
   SfSelect,
   SfInput,
   SfCheckbox,
-  SfAlert,
   SfIcon,
   SfHeading,
 } from "@storefront-ui/vue"
@@ -149,6 +148,7 @@ import {
 import { computed, ref } from "@vue/composition-api"
 import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
 import { sendContactForm } from "@shopware-pwa/shopware-6-client"
+import SwErrorsList from "@shopware-pwa/default-theme/components/SwErrorsList"
 
 export default {
   name: "CmsElementContactForm",
@@ -157,7 +157,7 @@ export default {
     SfInput,
     SfCheckbox,
     SwButton,
-    SfAlert,
+    SwErrorsList,
     SfIcon,
     SfHeading,
   },

--- a/packages/default-theme/cms/elements/CmsElementNesletterForm.vue
+++ b/packages/default-theme/cms/elements/CmsElementNesletterForm.vue
@@ -48,15 +48,7 @@
           />
         </transition>
 
-        <div v-if="errorMessage">
-          <SfAlert
-            v-for="(message, key) in errorMessage"
-            :key="key"
-            :message="message"
-            type="danger"
-            class="error-alert"
-          />
-        </div>
+        <SwErrorsList :list="errorMessage" />
 
         <span>
           <SwButton
@@ -72,7 +64,7 @@
 </template>
 
 <script>
-import { SfInput, SfHeading, SfAlert } from "@storefront-ui/vue"
+import { SfInput, SfHeading } from "@storefront-ui/vue"
 import { validationMixin } from "vuelidate"
 import { required, email } from "vuelidate/lib/validators"
 import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
@@ -80,6 +72,7 @@ import { newsletterSubscribe } from "@shopware-pwa/shopware-6-client"
 import { ref } from "@vue/composition-api"
 import { getApplicationContext } from "@shopware-pwa/composables"
 import { getMessagesFromErrorsArray } from "@shopware-pwa/helpers"
+import SwErrorsList from "@shopware-pwa/default-theme/components/SwErrorsList"
 
 export default {
   name: "CmsElementNewsletterForm",
@@ -87,7 +80,7 @@ export default {
     SfInput,
     SwButton,
     SfHeading,
-    SfAlert,
+    SwErrorsList,
   },
   mixins: [validationMixin],
   props: {

--- a/packages/default-theme/components/SwErrorsList.vue
+++ b/packages/default-theme/components/SwErrorsList.vue
@@ -1,0 +1,48 @@
+<template>
+  <div v-if="list" class="errors-list-component">
+    <SwAlert :message="alertMessage" type="danger" />
+
+    <ul class="list">
+      <li v-for="message in list" :key="message" class="item">{{ message }}</li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import SwAlert from "@shopware-pwa/default-theme/components/atoms/SwAlert"
+
+export default {
+  name: "SwErrorsList",
+  components: { SwAlert },
+  props: {
+    list: {
+      type: Array,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      alertMessage: "Encountered problems:",
+    }
+  },
+  setup(props, { root }) {
+    return {}
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.errors-list-component {
+  color: var(--_c-red-primary);
+  font-size: var(--font-sm);
+
+  .list {
+    margin-top: var(--spacer-xs);
+    padding-left: var(--spacer-xs);
+
+    .item {
+      list-style: inside;
+    }
+  }
+}
+</style>

--- a/packages/default-theme/components/SwErrorsList.vue
+++ b/packages/default-theme/components/SwErrorsList.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="list" class="errors-list-component">
-    <SwAlert :message="alertMessage" type="danger" />
+    <SwAlert :message="$t('Encountered problems:')" type="danger" />
 
     <ul class="list">
       <li v-for="message in list" :key="message" class="item">{{ message }}</li>
@@ -17,13 +17,8 @@ export default {
   props: {
     list: {
       type: Array,
-      default: null,
+      default: [],
     },
-  },
-  data() {
-    return {
-      alertMessage: "Encountered problems:",
-    }
   },
   setup(props, { root }) {
     return {}

--- a/packages/default-theme/components/atoms/SwAlert.vue
+++ b/packages/default-theme/components/atoms/SwAlert.vue
@@ -1,0 +1,27 @@
+<template>
+  <SfAlert :message="message" :type="type" />
+</template>
+
+<script>
+import { SfAlert } from "@storefront-ui/vue"
+
+export default {
+  name: "SwAlert",
+
+  components: {
+    SfAlert,
+  },
+
+  props: {
+    message: {
+      type: String,
+      default: "",
+    },
+
+    type: {
+      type: String,
+      default: "secondary",
+    },
+  },
+}
+</script>

--- a/packages/default-theme/components/forms/SwPassword.vue
+++ b/packages/default-theme/components/forms/SwPassword.vue
@@ -8,13 +8,7 @@
         </p>
       </slot>
 
-      <SfAlert
-        v-for="(message, index) in userErrorMessages"
-        :key="index"
-        class="sw-password__alert"
-        type="danger"
-        :message="message"
-      />
+      <SwErrorsList :list="userErrorMessages" />
 
       <div class="sw-password__form form">
         <slot name="form">
@@ -70,15 +64,15 @@
 import { validationMixin } from "vuelidate"
 import { required, minLength, sameAs } from "vuelidate/lib/validators"
 import { computed } from "@vue/composition-api"
-import { SfAlert } from "@storefront-ui/vue"
 import { useUser } from "@shopware-pwa/composables"
 import { getMessagesFromErrorsArray } from "@shopware-pwa/helpers"
 import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
 import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwErrorsList from "@shopware-pwa/default-theme/components/SwErrorsList"
 
 export default {
   name: "SwPassword",
-  components: { SwInput, SwButton, SfAlert },
+  components: { SwInput, SwButton, SwErrorsList },
   mixins: [validationMixin],
   props: {},
   setup(props, { root }) {

--- a/packages/default-theme/components/forms/SwPersonalInfo.vue
+++ b/packages/default-theme/components/forms/SwPersonalInfo.vue
@@ -8,12 +8,7 @@
         </p>
       </slot>
 
-      <SfAlert
-        v-if="userError"
-        class="sw-personal-info__alert"
-        type="danger"
-        :message="getErrorMessage"
-      />
+      <SwErrorsList :list="getErrorMessage" />
 
       <div class="sw-personal-info__form form">
         <slot name="form">
@@ -89,7 +84,6 @@
 </template>
 
 <script>
-import { computed, watch } from "@vue/composition-api"
 import { validationMixin } from "vuelidate"
 import {
   required,
@@ -98,23 +92,19 @@ import {
   minLength,
   sameAs,
 } from "vuelidate/lib/validators"
-import { SfSelect, SfProductOption, SfAlert, SfIcon } from "@storefront-ui/vue"
-import { useUser, useContext } from "@shopware-pwa/composables"
-import {
-  mapSalutations,
-  getMessagesFromErrorsArray,
-} from "@shopware-pwa/helpers"
+import { SfIcon } from "@storefront-ui/vue"
+import { useUser } from "@shopware-pwa/composables"
+import { getMessagesFromErrorsArray } from "@shopware-pwa/helpers"
 import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
 import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwErrorsList from "@shopware-pwa/default-theme/components/SwErrorsList"
 
 export default {
   name: "SwPersonalInfo",
   components: {
     SwInput,
     SwButton,
-    SfSelect,
-    SfProductOption,
-    SfAlert,
+    SwErrorsList,
     SfIcon,
   },
   mixins: [validationMixin],
@@ -157,7 +147,7 @@ export default {
     getErrorMessage() {
       return getMessagesFromErrorsArray(
         this.userError && this.userError.message
-      ).join("<br/>")
+      )
     },
     isEmailChanging() {
       return this.email !== (this.user && this.user.email)

--- a/packages/default-theme/locales/de-DE.json
+++ b/packages/default-theme/locales/de-DE.json
@@ -34,5 +34,6 @@
   "Cancel": "Stornieren",
   "Register today!": "Melde dich noch heute an!",
   "send": "senden",
-  "Please fill form data and check regulations acceptance.": "Bitte füllen Sie die Formulardaten aus und überprüfen Sie die Akzeptanz der Vorschriften."
+  "Please fill form data and check regulations acceptance.": "Bitte füllen Sie die Formulardaten aus und überprüfen Sie die Akzeptanz der Vorschriften.",
+  "Encountered problems": "Probleme gestoßen:"
 }

--- a/packages/default-theme/locales/en-GB.json
+++ b/packages/default-theme/locales/en-GB.json
@@ -34,5 +34,6 @@
   "Cancel": "Cancel",
   "Register today!": "Register today!",
   "send": "send",
-  "Please fill form data and check regulations acceptance.": "Please fill form data and check regulations acceptance."
+  "Please fill form data and check regulations acceptance.": "Please fill form data and check regulations acceptance.",
+  "Encountered problems": "Encountered problems:"
 }


### PR DESCRIPTION
closes #1053 

- We have created helper to get error messages as an array so here was created "styling component" screen below
- micro refactor on components where errors list exist
- replaced old errors with new ones

## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->



![Screenshot from 2020-09-01 17-33-48](https://user-images.githubusercontent.com/4071200/91949643-76f87a00-ed00-11ea-9e04-2b37e6b88c1f.png)

<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
