### PR TITLE
feat: extending available filter api #1043

### DIFF
--- a/packages/composables/__tests__/useProductListing.spec.ts
+++ b/packages/composables/__tests__/useProductListing.spec.ts
@@ -322,6 +322,10 @@ describe("Composables - useProductListing", () => {
                 color: undefined,
                 label: "Dicki, Gerhold and Witting",
                 value: undefined,
+                name: "Dicki, Gerhold and Witting",
+                translated: {
+                  name: "Dicki, Gerhold and Witting",
+                },
               },
             ],
             type: "entity",

--- a/packages/composables/__tests__/useProductListing.spec.ts
+++ b/packages/composables/__tests__/useProductListing.spec.ts
@@ -296,5 +296,38 @@ describe("Composables - useProductListing", () => {
         expect(productsTotal.value).toBeFalsy();
       });
     });
+
+    describe("availableFilters", () => {
+      it("should parse aggregations if the initial listing has any", () => {
+        const { availableFilters } = useProductListing(rootContextMock, {
+          aggregations: {
+            manufacturer: {
+              entities: [
+                {
+                  name: "Dicki, Gerhold and Witting",
+                  translated: {
+                    name: "Dicki, Gerhold and Witting",
+                  },
+                },
+              ],
+            },
+          },
+        } as any);
+
+        expect(availableFilters.value).toStrictEqual([
+          {
+            name: "manufacturer",
+            options: [
+              {
+                color: undefined,
+                label: "Dicki, Gerhold and Witting",
+                value: undefined,
+              },
+            ],
+            type: "entity",
+          },
+        ]);
+      });
+    });
   });
 });

--- a/packages/composables/__tests__/useProductSearch.spec.ts
+++ b/packages/composables/__tests__/useProductSearch.spec.ts
@@ -132,6 +132,10 @@ describe("Composables - useProductSearch", () => {
           name: "manufacturer",
           options: [
             {
+              translated: {
+                name: "DivanteLtd",
+              },
+              id: "123456",
               color: undefined,
               label: "DivanteLtd",
               value: "123456",

--- a/packages/composables/src/hooks/useProductListing.ts
+++ b/packages/composables/src/hooks/useProductListing.ts
@@ -89,7 +89,10 @@ export const useProductListing = (
     !productListingResult.value?.currentFilters?.manufacturer?.length &&
     !productListingResult.value?.currentFilters?.properties?.length;
 
-  sharedListing.products = initialListing?.elements || [];
+  if (initialListing?.elements && initialListing.elements.length) {
+    sharedListing.products = initialListing.elements;
+  }
+
   selectedCriteria.sorting = activeSorting.value;
 
   if (initialListing?.aggregations) {

--- a/packages/composables/src/hooks/useProductListing.ts
+++ b/packages/composables/src/hooks/useProductListing.ts
@@ -15,6 +15,7 @@ import {
   getFilterSearchCriteria,
   getSortingSearchCriteria,
   exportUrlQuery,
+  getListingAvailableFilters,
 } from "@shopware-pwa/helpers";
 import {
   useCms,
@@ -45,6 +46,7 @@ const sharedPagination = Vue.observable({
 
 const sharedListing = Vue.observable({
   products: [],
+  availableFilters: [],
 } as any);
 
 const selectedCriteria = Vue.observable({
@@ -82,6 +84,12 @@ export const useProductListing = (
 
   sharedListing.products = initialListing?.elements || [];
   selectedCriteria.sorting = activeSorting.value;
+
+  if (initialListing?.aggregations) {
+    sharedListing.availableFilters = getListingAvailableFilters(
+      initialListing.aggregations
+    );
+  }
 
   const resetFilters = () => {
     selectedCriteria.filters = {};
@@ -161,6 +169,9 @@ export const useProductListing = (
     );
     sharedPagination.total = (result && result.total) || 0;
     sharedListing.products = result?.elements || [];
+    sharedListing.availableFilters = getListingAvailableFilters(
+      result?.aggregations
+    );
     initialListing = undefined;
     loading.value = false;
   };
@@ -194,6 +205,7 @@ export const useProductListing = (
   ]);
   const selectedFilters = computed(() => localCriteria.filters);
   const selectedSorting = computed(() => localCriteria.sorting);
+  const availableFilters = computed(() => localListing.availableFilters);
 
   return {
     search,
@@ -210,5 +222,6 @@ export const useProductListing = (
     changeSorting,
     selectedSorting,
     categoryId,
+    availableFilters,
   };
 };

--- a/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
+++ b/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
@@ -126,7 +126,7 @@ export default {
     },
   },
   setup(props, { root }) {
-    const { availableFilters, availableSorting } = useCategoryFilters(root)
+    const { availableSorting } = useCategoryFilters(root)
     const {
       toggleFilter,
       changeSorting,
@@ -136,6 +136,7 @@ export default {
       selectedEntityFilters,
       resetFilters,
       productsTotal,
+      availableFilters,
     } = useProductListing(root, null)
 
     const { isOpen: isListView, switchState: switchToListView } = useUIState(

--- a/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
+++ b/packages/default-theme/cms/elements/CmsElementCategorySidebarFilter.vue
@@ -137,6 +137,7 @@ export default {
       resetFilters,
       productsTotal,
       availableFilters,
+      changePagination,
     } = useProductListing(root, null)
 
     const { isOpen: isListView, switchState: switchToListView } = useUIState(
@@ -157,6 +158,7 @@ export default {
       switchToListView,
       availableFilters,
       availableSorting,
+      changePagination,
     }
   },
   data() {
@@ -202,11 +204,11 @@ export default {
     },
     async clearAllFilters() {
       this.resetFilters()
-      await this.search()
+      await this.changePagination(1)
       this.isFilterSidebarOpen = false
     },
     async submitFilters() {
-      await this.search()
+      await this.changePagination(1)
       this.isFilterSidebarOpen = false
     },
     getSortLabel(sorting) {

--- a/packages/default-theme/cms/elements/CmsElementProductListing.vue
+++ b/packages/default-theme/cms/elements/CmsElementProductListing.vue
@@ -99,7 +99,6 @@ export default {
     },
   },
   setup({ content }, { root }) {
-    const { search } = useProductSearch(root)
     const listing = content.data.listing || []
     const {
       products,

--- a/packages/default-theme/components/listing/types/range.vue
+++ b/packages/default-theme/components/listing/types/range.vue
@@ -42,7 +42,7 @@ export default {
   },
   setup({ filter, selectedValues }, { emit }) {
     const min = computed({
-      get: () => selectedValues.gt || filter.options.min,
+      get: () => selectedValues.gt || filter.min,
       set: (value) =>
         emit("toggle-filter-value", {
           type: "range",
@@ -53,7 +53,7 @@ export default {
         }),
     })
     const max = computed({
-      get: () => selectedValues.lt || filter.options.max,
+      get: () => selectedValues.lt || filter.max,
       set: (value) =>
         emit("toggle-filter-value", {
           type: "range",

--- a/packages/helpers/__tests__/listing/getListingAvailableFilters.spec.ts
+++ b/packages/helpers/__tests__/listing/getListingAvailableFilters.spec.ts
@@ -42,42 +42,7 @@ describe("Shopware helpers - getListingAvailableFilters", () => {
       },
     ]);
   });
-  it("should return transformed filter if properties property is resolved", () => {
-    const aggregations = {
-      properties: {
-        entities: [
-          {
-            name: "color",
-            options: [
-              {
-                name: "mediumblue",
-                colorHexCode: "#ffc",
-                translated: {
-                  name: "mediumblue",
-                },
-                id: "e4af09b1c8ac463ca7a61fac99e71226",
-              },
-            ],
-            id: "8c6aadfc5ed84a7db0b54935e3f60403",
-          },
-        ],
-      },
-    } as any;
-    const result = getListingAvailableFilters(aggregations);
-    expect(result).toEqual([
-      {
-        name: "color",
-        options: [
-          {
-            color: "#ffc",
-            label: "mediumblue",
-            value: "e4af09b1c8ac463ca7a61fac99e71226",
-          },
-        ],
-        type: "entity",
-      },
-    ]);
-  });
+
   it("should return an empty array if resolved aggregation has no values", () => {
     const aggregation = {
       manufacturer: {},

--- a/packages/helpers/__tests__/listing/getListingAvailableFilters.spec.ts
+++ b/packages/helpers/__tests__/listing/getListingAvailableFilters.spec.ts
@@ -56,6 +56,47 @@ describe("Shopware helpers - getListingAvailableFilters", () => {
     expect(result).toEqual([]);
   });
 
+  it("should treat properties aggregation differently", () => {
+    const aggregation = {
+      properties: {
+        entities: [
+          {
+            name: "color",
+            options: [
+              {
+                id: "white",
+                name: "white",
+                colorHexCode: "#fff",
+                translated: {
+                  name: "white",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    } as any;
+
+    const result = getListingAvailableFilters(aggregation);
+    expect(result).toStrictEqual([
+      {
+        name: "color",
+        options: [
+          {
+            colorHexCode: "#fff",
+            color: "#fff",
+            id: "white",
+            label: "white",
+            name: "white",
+            translated: { name: "white" },
+            value: "white",
+          },
+        ],
+        type: "entity",
+      },
+    ]);
+  });
+
   it("should handle max filter type", () => {
     const aggregation = {
       "shipping-free": {

--- a/packages/helpers/__tests__/listing/getListingAvailableFilters.spec.ts
+++ b/packages/helpers/__tests__/listing/getListingAvailableFilters.spec.ts
@@ -34,8 +34,12 @@ describe("Shopware helpers - getListingAvailableFilters", () => {
         options: [
           {
             color: undefined,
+            id: "2cc7db79c4214b448df87fb6642ebc57",
             label: "Rolfson-Schuppe",
             value: "2cc7db79c4214b448df87fb6642ebc57",
+            translated: {
+              name: "Rolfson-Schuppe",
+            },
           },
         ],
         type: "entity",
@@ -50,5 +54,44 @@ describe("Shopware helpers - getListingAvailableFilters", () => {
 
     const result = getListingAvailableFilters(aggregation);
     expect(result).toEqual([]);
+  });
+
+  it("should handle max filter type", () => {
+    const aggregation = {
+      "shipping-free": {
+        max: "1",
+      },
+    } as any;
+
+    const result = getListingAvailableFilters(aggregation);
+    expect(result).toEqual([
+      {
+        max: "1",
+        name: "shipping-free",
+        type: "max",
+      },
+    ]);
+  });
+  it("should handle range filter type", () => {
+    const aggregation = {
+      price: {
+        min: "50",
+        max: "974",
+        avg: 770.5172413793103,
+        sum: 22345,
+      },
+    } as any;
+
+    const result = getListingAvailableFilters(aggregation);
+    expect(result).toEqual([
+      {
+        max: "974",
+        name: "price",
+        type: "range",
+        min: "50",
+        avg: 770.5172413793103,
+        sum: 22345,
+      },
+    ]);
   });
 });

--- a/packages/helpers/src/listing/filters.ts
+++ b/packages/helpers/src/listing/filters.ts
@@ -93,7 +93,7 @@ export const getFilterSearchCriteria = (selectedFilters: any): any[] => {
     try {
       filters.push(extractFilter(filterName, selectedFilters[filterName]));
     } catch (error) {
-      console.error("helpers:getFilterSearchCriteria:extractFilter", error);
+      console.warn("helpers:getFilterSearchCriteria:extractFilter", error);
     }
   }
 

--- a/packages/helpers/src/listing/getListingAvailableFilters.ts
+++ b/packages/helpers/src/listing/getListingAvailableFilters.ts
@@ -9,11 +9,11 @@ const getFilterType = (aggregation: any) => {
     return UiCategoryFilterType.entity;
   }
 
-  if (aggregation.min && aggregation.max) {
+  if (aggregation.hasOwnProperty("max") && aggregation.hasOwnProperty("min")) {
     return UiCategoryFilterType.range;
   }
 
-  if (aggregation.max && !aggregation.min) {
+  if (aggregation.hasOwnProperty("max") && !aggregation.min) {
     return UiCategoryFilterType.max;
   }
 
@@ -50,14 +50,24 @@ export function getListingAvailableFilters(
     return [];
   }
   const transformedFilters: UiCategoryFilter[] = [];
+  // first level aggregations
   for (const [aggregationName, aggregation] of Object.entries(aggregations)) {
     try {
       const filterType = getFilterType(aggregation);
       // entity type
       if (filterType === UiCategoryFilterType.entity) {
-        transformedFilters.push(
-          extractEntityTypeFilter(aggregationName, aggregation.entities)
-        );
+        // some of the aggregations are grouped as a properties and have different structure
+        if (aggregationName === "properties") {
+          for (const property of aggregation.entities) {
+            transformedFilters.push(
+              extractEntityTypeFilter(property.name, property.options)
+            );
+          }
+        } else {
+          transformedFilters.push(
+            extractEntityTypeFilter(aggregationName, aggregation.entities)
+          );
+        }
       } else {
         // other types
         transformedFilters.push({

--- a/packages/helpers/src/listing/getListingAvailableFilters.ts
+++ b/packages/helpers/src/listing/getListingAvailableFilters.ts
@@ -4,6 +4,22 @@ import {
   AggregationFilterEntityOption,
 } from "@shopware-pwa/commons/interfaces/search/Aggregations";
 
+const getFilterType = (aggregation: any) => {
+  if (aggregation.entities && Array.isArray(aggregation.entities)) {
+    return UiCategoryFilterType.entity;
+  }
+
+  if (aggregation.min && aggregation.max) {
+    return UiCategoryFilterType.range;
+  }
+
+  if (aggregation.max && !aggregation.min) {
+    return UiCategoryFilterType.max;
+  }
+
+  throw new Error("Unrecognized type");
+};
+
 /**
  * TODO: https://github.com/DivanteLtd/shopware-pwa/issues/841
  * TODO: https://github.com/DivanteLtd/shopware-pwa/issues/840
@@ -20,6 +36,7 @@ const extractEntityTypeFilter = (
     value: filterData.id,
     // false when there's no color property is fine, UI accepts it
     color: filterData.colorHexCode,
+    ...filterData, // pass additional info that may be useful
   })),
 });
 
@@ -34,9 +51,24 @@ export function getListingAvailableFilters(
   }
   const transformedFilters: UiCategoryFilter[] = [];
   for (const [aggregationName, aggregation] of Object.entries(aggregations)) {
-    if (Array.isArray(aggregation.entities)) {
-      transformedFilters.push(
-        extractEntityTypeFilter(aggregationName, aggregation.entities)
+    try {
+      const filterType = getFilterType(aggregation);
+      // entity type
+      if (filterType === UiCategoryFilterType.entity) {
+        transformedFilters.push(
+          extractEntityTypeFilter(aggregationName, aggregation.entities)
+        );
+      } else {
+        // other types
+        transformedFilters.push({
+          name: aggregationName,
+          type: filterType,
+          ...aggregation,
+        });
+      }
+    } catch (error) {
+      console.warn(
+        `[helpers][getListingAvailableFilters][getFilterType]: ${error} | ${aggregationName}`
       );
     }
   }

--- a/packages/helpers/src/listing/getListingAvailableFilters.ts
+++ b/packages/helpers/src/listing/getListingAvailableFilters.ts
@@ -34,21 +34,10 @@ export function getListingAvailableFilters(
   }
   const transformedFilters: UiCategoryFilter[] = [];
   for (const [aggregationName, aggregation] of Object.entries(aggregations)) {
-    if (
-      aggregationName === "manufacturer" &&
-      Array.isArray(aggregation.entities)
-    ) {
+    if (Array.isArray(aggregation.entities)) {
       transformedFilters.push(
         extractEntityTypeFilter(aggregationName, aggregation.entities)
       );
-    }
-
-    if (aggregationName === "properties") {
-      for (const filter of aggregation.entities) {
-        transformedFilters.push(
-          extractEntityTypeFilter(filter.name, filter.options)
-        );
-      }
     }
   }
 


### PR DESCRIPTION
## Changes
closes #1043 
closes #1058
closes #1057
closes #834 

- [x] get filters from product-listing slot's aggregations
- [x] change the source of availableFilters to useProductListing composable

TODO:
- [x] extend the available filters returned interface



<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
