### PR TITLE
Fix/image text blocks distinction #1065

### DIFF
--- a/packages/default-theme/cms/blocks/CmsBlockImageText.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockImageText.vue
@@ -1,0 +1,84 @@
+<template>
+  <article class="cms-block-image-text">
+    <CmsGenericElement
+      :content="getLeftContent"
+      class="cms-block-image-text__image"
+    />
+    <CmsGenericElement
+      :content="getRightContent"
+      class="cms-block-image-text__text"
+    />
+  </article>
+</template>
+
+<script>
+import CmsGenericElement from "sw-cms/CmsGenericElement"
+
+export default {
+  name: "CmsBlockImageText",
+
+  components: {
+    CmsGenericElement,
+  },
+
+  props: {
+    content: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+
+  computed: {
+    getSlots() {
+      return this.content.slots || []
+    },
+
+    getLeftContent() {
+      return this.getSlots.find(({ slot }) => slot === "left")
+    },
+    getRightContent() {
+      return this.getSlots.find(({ slot }) => slot === "right")
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import "@/assets/scss/variables";
+
+.cms-block-image-text {
+  display: flex;
+  flex-direction: column;
+  margin-right: 0;
+  margin-left: 0;
+
+  &__image,
+  &__text {
+    margin: var(--spacer-sm);
+    flex: 1;
+    & img {
+      height: 340px;
+      object-fit: cover;
+      width: 100%;
+    }
+  }
+
+  @include for-desktop {
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-around;
+
+    .cms-block-image-text__image {
+      margin-bottom: 0;
+      margin-right: var(--spacer-sm);
+      margin-top: 0;
+    }
+
+    .cms-block-image-text__text {
+      margin-bottom: 0;
+      margin-left: var(--spacer-sm);
+      margin-top: 0;
+    }
+  }
+}
+</style>

--- a/packages/default-theme/cms/blocks/CmsBlockTextOnImage.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockTextOnImage.vue
@@ -1,12 +1,9 @@
 <template>
   <article class="cms-block-text-on-image">
     <CmsGenericElement
-      :content="getLeftContent"
-      class="cms-block-text-on-image__image"
-    />
-    <CmsGenericElement
-      :content="getRightContent"
-      class="cms-block-text-on-image__text"
+      v-if="getContent"
+      :content="getContent"
+      class="cms-block-text-on-image__content"
     />
   </article>
 </template>
@@ -33,11 +30,8 @@ export default {
       return this.content.slots || []
     },
 
-    getLeftContent() {
-      return this.getSlots.find(({ slot }) => slot === "left")
-    },
-    getRightContent() {
-      return this.getSlots.find(({ slot }) => slot === "right")
+    getContent() {
+      return this.getSlots.length && this.getSlots[0]
     },
   },
 }
@@ -45,40 +39,4 @@ export default {
 
 <style lang="scss" scoped>
 @import "@/assets/scss/variables";
-
-.cms-block-text-on-image {
-  display: flex;
-  flex-direction: column;
-  margin-right: 0;
-  margin-left: 0;
-
-  &__image,
-  &__text {
-    margin: var(--spacer-sm);
-    flex: 1;
-    & img {
-      height: 340px;
-      object-fit: cover;
-      width: 100%;
-    }
-  }
-
-  @include for-desktop {
-    align-items: center;
-    flex-direction: row;
-    justify-content: space-around;
-
-    .cms-block-text-on-image__image {
-      margin-bottom: 0;
-      margin-right: var(--spacer-sm);
-      margin-top: 0;
-    }
-
-    .cms-block-text-on-image__text {
-      margin-bottom: 0;
-      margin-left: var(--spacer-sm);
-      margin-top: 0;
-    }
-  }
-}
 </style>

--- a/packages/default-theme/cms/blocks/CmsBlockTextOnImage.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockTextOnImage.vue
@@ -39,4 +39,13 @@ export default {
 
 <style lang="scss" scoped>
 @import "@/assets/scss/variables";
+
+.cms-block-text-on-image {
+  background-position: center;
+  background-size: cover;
+
+  &__content {
+    padding: var(--spacer-2xl) var(--spacer-xl);
+  }
+}
 </style>

--- a/packages/default-theme/cms/cmsMap.json
+++ b/packages/default-theme/cms/cmsMap.json
@@ -7,7 +7,7 @@
     "text-on-image": "CmsBlockTextOnImage",
     "sidebar-filter": "CmsBlockDefault",
     "product-listing": "CmsBlockDefault",
-    "image-text": "CmsBlockTextOnImage",
+    "image-text": "CmsBlockImageText",
     "image": "CmsBlockDefault",
     "image-cover": "CmsBlockImageCover",
     "category-navigation": "CmsBlockCategoryNavigation",


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

closes #1065 

    Created separate file/block for (image text block)
    
    Reverted changes in (text on image block)




<!-- Paste here screenshot if there are visual changes -->
Fixed text on image banner at homepage:
![Screenshot from 2020-09-03 12-19-42](https://user-images.githubusercontent.com/4071200/92103183-e1341c00-eddf-11ea-84b3-3486ca46bf87.png)


Image next to text still looks good:
![Screenshot from 2020-09-03 12-19-57](https://user-images.githubusercontent.com/4071200/92103224-ef823800-eddf-11ea-88c8-83964a9bc80b.png)





### Checklist

- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
