### PR TITLE
fix(default-theme): fix for scrolling page after closing cart

### DIFF
--- a/packages/default-theme/components/SwCart.vue
+++ b/packages/default-theme/components/SwCart.vue
@@ -128,6 +128,8 @@ export default {
       removeProduct,
     }
   },
+
+  // TODO: hotfix - not final solution. To remove after fix cause of a problem.
   watch: {
     isSidebarOpen(val) {
       if (!val) {

--- a/packages/default-theme/components/SwCart.vue
+++ b/packages/default-theme/components/SwCart.vue
@@ -57,8 +57,8 @@
             </SfProperty>
             <SwButton
               class="sf-button--full-width color-secondary"
-              @click="goToCheckout()"
               data-cy="goToCheckout-button"
+              @click="goToCheckout()"
               >{{ $t("Go to checkout") }}</SwButton
             >
             <SwPluginSlot name="sidecart-checkout-button-after" />
@@ -127,6 +127,13 @@ export default {
       totalPrice,
       removeProduct,
     }
+  },
+  watch: {
+    isSidebarOpen(val) {
+      if (!val) {
+        document.body.style.overflow = "auto"
+      }
+    },
   },
   methods: {
     goToCheckout() {


### PR DESCRIPTION
## Changes
<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
Fix for scrolling page after closing the cart sidebar.

closes #915 closes #1081 




<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
