### PR TITLE
fix(default-theme): hide error notifications when the list is empty

### DIFF
--- a/packages/default-theme/components/SwErrorsList.vue
+++ b/packages/default-theme/components/SwErrorsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="list" class="errors-list-component">
+  <div v-if="Array.isArray(list) && list.length" class="errors-list-component">
     <SwAlert :message="$t('Encountered problems:')" type="danger" />
 
     <ul class="list">


### PR DESCRIPTION
## Changes
hide the encountered problems list above the specific form when the list is empty




<!-- Paste here screenshot if there are visual changes -->





### Checklist

- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
