### PR TITLE
refactor(default-theme): change theme aliases to @ in theme and project

### DIFF
--- a/api/composables.api.md
+++ b/api/composables.api.md
@@ -37,7 +37,6 @@ import { SessionContext } from '@shopware-pwa/commons/interfaces/response/Sessio
 import { ShippingAddress } from '@shopware-pwa/commons/interfaces/request/GuestOrderParams';
 import { ShippingMethod } from '@shopware-pwa/commons/interfaces/models/checkout/shipping/ShippingMethod';
 import { ShopwareApiInstance } from '@shopware-pwa/shopware-6-client';
-import { ShopwareAssociation } from '@shopware-pwa/commons/interfaces/search/Association';
 import { ShopwareSearchParams } from '@shopware-pwa/commons/interfaces/search/SearchCriteria';
 import { Sort } from '@shopware-pwa/commons/interfaces/search/SearchCriteria';
 import { VueConstructor } from 'vue';
@@ -138,10 +137,7 @@ export function getApplicationContext(rootContext: ApplicationVueContext, key?: 
 
 // @beta
 export function getDefaultApiParams(): {
-    [composableName: string]: {
-        includes?: Includes;
-        associations?: ShopwareAssociation;
-    };
+    [composableName: string]: ShopwareSearchParams;
 };
 
 // @beta

--- a/docs/landing/getting-started/upgrade.md
+++ b/docs/landing/getting-started/upgrade.md
@@ -34,7 +34,7 @@ All changes are documented in our [Changelog](https://github.com/DivanteLtd/shop
 
 **BREAKING CHANGE**: we've made overriding store more simple. If you don't need a store just leave `store` directory empty or remove it. If you need to use it though, then create `src/store/indexjs` file and attach theme store.
 
-**FEATURE**: you can now safely use `@/components/COMPONENT_NAME.vue`instead of `@shopware-pwa/default-themee/components/COMPONENT_NAME.vue` inside your project. It's not a break - old aliases will stay the same.
+**FEATURE**: you can now safely use `@/components/COMPONENT_NAME.vue`instead of `@shopware-pwa/default-theme/components/COMPONENT_NAME.vue` inside your project. It's not a break - old aliases will stay the same.
 So for example instead of:
 `import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"`
 you can type

--- a/docs/landing/resources/api/composables.getdefaultapiparams.md
+++ b/docs/landing/resources/api/composables.getdefaultapiparams.md
@@ -13,13 +13,10 @@ Returns default system API params
 
 ```typescript
 export declare function getDefaultApiParams(): {
-    [composableName: string]: {
-        includes?: Includes;
-        associations?: ShopwareAssociation;
-    };
+    [composableName: string]: ShopwareSearchParams;
 };
 ```
 <b>Returns:</b>
 
-{ \[composableName: string\]: { includes?: Includes; associations?: ShopwareAssociation; }; }
+{ \[composableName: string\]: ShopwareSearchParams; }
 

--- a/docs/landing/resources/api/composables.usedefaults.md
+++ b/docs/landing/resources/api/composables.usedefaults.md
@@ -5,6 +5,7 @@
 ## useDefaults variable
 
 > This API is provided as a preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+> 
 
 Returns default config depending on config key. It is used in composables, so defaultsKey is in most cases composable name (ex. `useDefaults(rootContext, "useCms")`<!-- -->)
 
@@ -12,10 +13,10 @@ Returns default config depending on config key. It is used in composables, so de
 
 ```typescript
 useDefaults: (rootContext: ApplicationVueContext, defaultsKey: string) => {
-  getIncludesConfig: () => Includes;
-  getAssociationsConfig: () => ShopwareAssociation;
-  getDefaults: () => ShopwareSearchParams;
-};
+    getIncludesConfig: () => Includes;
+    getAssociationsConfig: () => Association[];
+    getDefaults: () => ShopwareSearchParams;
+}
 ```
 
 ## Remarks
@@ -28,17 +29,18 @@ To extend defaults you need to add configuration to `shopware-pwa.config.js` fil
 module.exports = {
   // ... other settings
   apiDefaults: {
-    useCms: {
-      limit: 8,
-      includes: {
-        product: ["manufacturer"],
-      },
-      associations: {
-        media: {},
-      },
-    },
+   useCms: {
+     limit: 8,
+     includes: {
+       product: ["manufacturer"]
+     },
+     associations: [
+       { name: "media" }
+     ]
+   },
   },
-};
-```
+}
 
+```
 We need to remember the structure of includes and associations. You can read more about this [in shopware docs](https://docs.shopware.com/en/shopware-platform-dev-en/admin-api-guide/reading-entities?category=shopware-platform-dev-en/admin-api-guide#parameter-overview)<!-- -->.
+

--- a/packages/composables/src/getDefaultApiParams.ts
+++ b/packages/composables/src/getDefaultApiParams.ts
@@ -1,6 +1,5 @@
 import defaultApiParams from "./internalHelpers/defaultApiParams.json";
-import { Includes } from "@shopware-pwa/commons/interfaces/search/SearchCriteria";
-import { ShopwareAssociation } from "@shopware-pwa/commons/interfaces/search/Association";
+import { ShopwareSearchParams } from "@shopware-pwa/commons/interfaces/search/SearchCriteria";
 
 /**
  * Returns default system API params
@@ -8,10 +7,7 @@ import { ShopwareAssociation } from "@shopware-pwa/commons/interfaces/search/Ass
  * @beta
  */
 export function getDefaultApiParams(): {
-  [composableName: string]: {
-    includes?: Includes;
-    associations?: ShopwareAssociation;
-  };
+  [composableName: string]: ShopwareSearchParams;
 } {
   return defaultApiParams;
 }

--- a/packages/composables/src/hooks/useCms/index.ts
+++ b/packages/composables/src/hooks/useCms/index.ts
@@ -37,7 +37,6 @@ export const useCms = (rootContext: ApplicationVueContext): any => {
     const searchCriteria = merge({}, getDefaults(), criteria);
 
     try {
-      console.warn("search page", searchCriteria);
       const result = await getCmsPage(path, searchCriteria, apiInstance);
       vuexStore.commit("SET_PAGE", result);
     } catch (e) {

--- a/packages/composables/src/internalHelpers/defaultApiParams.json
+++ b/packages/composables/src/internalHelpers/defaultApiParams.json
@@ -124,6 +124,9 @@
       ]
     }
   },
+  "useProductQuickSearch": {
+    "limit": 10
+  },
   "useListing": {
     "limit": 10,
     "includes": {

--- a/packages/default-theme/cms/blocks/CmsBlockImageTextGallery.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockImageTextGallery.vue
@@ -42,8 +42,8 @@
 </template>
 
 <script>
-import CmsElementImage from "@shopware-pwa/default-theme/cms/elements/CmsElementImage"
-import CmsElementText from "@shopware-pwa/default-theme/cms/elements/CmsElementText"
+import CmsElementImage from "@/cms/elements/CmsElementImage"
+import CmsElementText from "@/cms/elements/CmsElementText"
 
 const extractGalleryData = (slots, position) => {
   const image = slots.find((slot) => slot.slot === `${position}-image`)

--- a/packages/default-theme/cms/blocks/CmsBlockProductThreeColumn.vue
+++ b/packages/default-theme/cms/blocks/CmsBlockProductThreeColumn.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script>
-import CmsElementProductCard from "@shopware-pwa/default-theme/cms/elements/CmsElementProductCard"
+import CmsElementProductCard from "@/cms/elements/CmsElementProductCard"
 
 export default {
   name: "CmsBlockProductThreeColumn",

--- a/packages/default-theme/cms/elements/CmsElementCategoryNavigation.vue
+++ b/packages/default-theme/cms/elements/CmsElementCategoryNavigation.vue
@@ -11,7 +11,7 @@
           :key="accordion.id"
           :header="accordion.name"
         >
-          <template #header="{header, isOpen, accordionClick}">
+          <template #header="{ header, isOpen, accordionClick }">
             <div class="cms-element-category-navigation__menu-item">
               <nuxt-link :to="$i18n.path(getCategoryUrl(accordion))">
                 <SwButton
@@ -67,7 +67,7 @@ import {
 } from "@storefront-ui/vue"
 import { getNavigation } from "@shopware-pwa/shopware-6-client"
 import { useCms } from "@shopware-pwa/composables"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 import { getCategoryUrl } from "@shopware-pwa/helpers"
 
 export default {

--- a/packages/default-theme/cms/elements/CmsElementContactForm.vue
+++ b/packages/default-theme/cms/elements/CmsElementContactForm.vue
@@ -146,9 +146,9 @@ import {
   getApplicationContext,
 } from "@shopware-pwa/composables"
 import { computed, ref } from "@vue/composition-api"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 import { sendContactForm } from "@shopware-pwa/shopware-6-client"
-import SwErrorsList from "@shopware-pwa/default-theme/components/SwErrorsList"
+import SwErrorsList from "@/components/SwErrorsList"
 
 export default {
   name: "CmsElementContactForm",

--- a/packages/default-theme/cms/elements/CmsElementForm.vue
+++ b/packages/default-theme/cms/elements/CmsElementForm.vue
@@ -16,14 +16,8 @@ export default {
   data() {
     return {
       map: {
-        newsletter: () =>
-          import(
-            "@shopware-pwa/default-theme/cms/elements/CmsElementNesletterForm"
-          ),
-        contact: () =>
-          import(
-            "@shopware-pwa/default-theme/cms/elements/CmsElementContactForm"
-          ),
+        newsletter: () => import("@/cms/elements/CmsElementNesletterForm"),
+        contact: () => import("@/cms/elements/CmsElementContactForm"),
       },
     }
   },

--- a/packages/default-theme/cms/elements/CmsElementImage.vue
+++ b/packages/default-theme/cms/elements/CmsElementImage.vue
@@ -26,7 +26,7 @@
 <script>
 import { getCmsLink, getCmsLinkTarget } from "@shopware-pwa/helpers"
 import { SfImage } from "@storefront-ui/vue"
-import SwLink from "@shopware-pwa/default-theme/components/atoms/SwLink"
+import SwLink from "@/components/atoms/SwLink"
 
 export default {
   name: "CmsElementImage",

--- a/packages/default-theme/cms/elements/CmsElementImageSlider.vue
+++ b/packages/default-theme/cms/elements/CmsElementImageSlider.vue
@@ -14,9 +14,7 @@
           :to="$i18n.path(slide.url)"
           class="cms-element-image-slider__link"
         >
-          <SwButton class="sf-button">
-            See more
-          </SwButton>
+          <SwButton class="sf-button"> See more </SwButton>
         </nuxt-link>
       </template>
     </SfHeroItem>
@@ -25,7 +23,7 @@
 
 <script>
 import { SfHero } from "@storefront-ui/vue"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 
 export default {
   name: "CmsElementImageSlider",

--- a/packages/default-theme/cms/elements/CmsElementNesletterForm.vue
+++ b/packages/default-theme/cms/elements/CmsElementNesletterForm.vue
@@ -67,12 +67,12 @@
 import { SfInput, SfHeading } from "@storefront-ui/vue"
 import { validationMixin } from "vuelidate"
 import { required, email } from "vuelidate/lib/validators"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 import { newsletterSubscribe } from "@shopware-pwa/shopware-6-client"
 import { ref } from "@vue/composition-api"
 import { getApplicationContext } from "@shopware-pwa/composables"
 import { getMessagesFromErrorsArray } from "@shopware-pwa/helpers"
-import SwErrorsList from "@shopware-pwa/default-theme/components/SwErrorsList"
+import SwErrorsList from "@/components/SwErrorsList"
 
 export default {
   name: "CmsElementNewsletterForm",

--- a/packages/default-theme/cms/elements/CmsElementProductCard.vue
+++ b/packages/default-theme/cms/elements/CmsElementProductCard.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import SwProductCard from "@shopware-pwa/default-theme/components/SwProductCard"
+import SwProductCard from "@/components/SwProductCard"
 
 export default {
   components: {

--- a/packages/default-theme/cms/elements/CmsElementProductSlider.vue
+++ b/packages/default-theme/cms/elements/CmsElementProductSlider.vue
@@ -12,7 +12,7 @@
 
 <script>
 import { SfSection, SfCarousel } from "@storefront-ui/vue"
-import SwProductCard from "@shopware-pwa/default-theme/components/SwProductCard"
+import SwProductCard from "@/components/SwProductCard"
 
 export default {
   name: "CmsElementProductSlider",

--- a/packages/default-theme/cms/elements/CmsElementText.vue
+++ b/packages/default-theme/cms/elements/CmsElementText.vue
@@ -1,7 +1,7 @@
 <script>
 // import any extra components here
 import { SfLink } from "@storefront-ui/vue"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 import { renderHtml } from "html-to-vue"
 
 export default {

--- a/packages/default-theme/components/SwAddressList.vue
+++ b/packages/default-theme/components/SwAddressList.vue
@@ -15,7 +15,7 @@
 </template>
 <script>
 import { useUser } from "@shopware-pwa/composables"
-import Address from "@shopware-pwa/default-theme/components/account/MyAddresses/Address.vue"
+import Address from "@/components/account/MyAddresses/Address.vue"
 
 export default {
   name: "MyAddresses",

--- a/packages/default-theme/components/SwBottomNavigation.vue
+++ b/packages/default-theme/components/SwBottomNavigation.vue
@@ -21,7 +21,7 @@
           <SfIcon
             icon="menu"
             size="20px"
-            style="width: 25px;"
+            style="width: 25px"
             @click="toggleMobileNavigation"
           />
           <!-- TODO: remove transition after animation fix in SFUI -->
@@ -116,11 +116,11 @@ import {
   SfMenuItem,
 } from "@storefront-ui/vue"
 import { useUIState, useUser, useCart } from "@shopware-pwa/composables"
-import SwCurrencySwitcher from "@shopware-pwa/default-theme/components/SwCurrencySwitcher"
+import SwCurrencySwitcher from "@/components/SwCurrencySwitcher"
 import { onMounted } from "@vue/composition-api"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import SwBottomMenu from "@shopware-pwa/default-theme/components/SwBottomMenu"
-import { PAGE_ACCOUNT } from "@shopware-pwa/default-theme/helpers/pages"
+import SwButton from "@/components/atoms/SwButton"
+import SwBottomMenu from "@/components/SwBottomMenu"
+import { PAGE_ACCOUNT } from "@/helpers/pages"
 import { getCategoryUrl } from "@shopware-pwa/helpers"
 
 export default {

--- a/packages/default-theme/components/SwCart.vue
+++ b/packages/default-theme/components/SwCart.vue
@@ -85,9 +85,9 @@ import {
   SfImage,
 } from "@storefront-ui/vue"
 import { useCart, useUIState } from "@shopware-pwa/composables"
-import SwCartProduct from "@shopware-pwa/default-theme/components/SwCartProduct"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import { PAGE_CHECKOUT } from "@shopware-pwa/default-theme/helpers/pages"
+import SwCartProduct from "@/components/SwCartProduct"
+import SwButton from "@/components/atoms/SwButton"
+import { PAGE_CHECKOUT } from "@/helpers/pages"
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
 import { computed, onMounted, ref } from "@vue/composition-api"
 

--- a/packages/default-theme/components/SwErrorsList.vue
+++ b/packages/default-theme/components/SwErrorsList.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-import SwAlert from "@shopware-pwa/default-theme/components/atoms/SwAlert"
+import SwAlert from "@/components/atoms/SwAlert"
 
 export default {
   name: "SwErrorsList",

--- a/packages/default-theme/components/SwFooter.vue
+++ b/packages/default-theme/components/SwFooter.vue
@@ -27,7 +27,7 @@
 
 <script>
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import SwFooterNavigation from "@shopware-pwa/default-theme/components/organisms/SwFooterNavigation"
+import SwFooterNavigation from "@/components/organisms/SwFooterNavigation"
 
 export default {
   name: "SwFooter",

--- a/packages/default-theme/components/SwHeader.vue
+++ b/packages/default-theme/components/SwHeader.vue
@@ -32,13 +32,13 @@
 import { SfHeader, SfOverlay } from "@storefront-ui/vue"
 import { useUIState } from "@shopware-pwa/composables"
 
-import SwTopBar from "@shopware-pwa/default-theme/components/SwTopBar"
-import SwLogo from "@shopware-pwa/default-theme/components/SwLogo"
-import SwHeaderIcons from "@shopware-pwa/default-theme/components/SwHeaderIcons"
-import SwTopNavigation from "@shopware-pwa/default-theme/components/SwTopNavigation"
-import SwSearchBar from "@shopware-pwa/default-theme/components/SwSearchBar"
+import SwTopBar from "@/components/SwTopBar"
+import SwLogo from "@/components/SwLogo"
+import SwHeaderIcons from "@/components/SwHeaderIcons"
+import SwTopNavigation from "@/components/SwTopNavigation"
+import SwSearchBar from "@/components/SwSearchBar"
 
-import SwCookieBar from "@shopware-pwa/default-theme/components/gdpr/SwCookieBar"
+import SwCookieBar from "@/components/gdpr/SwCookieBar"
 
 export default {
   components: {

--- a/packages/default-theme/components/SwHeaderIcons.vue
+++ b/packages/default-theme/components/SwHeaderIcons.vue
@@ -60,9 +60,9 @@
 import { SfList, SfDropdown, SfIcon } from "@storefront-ui/vue"
 import { useUser, useCart, useUIState } from "@shopware-pwa/composables"
 
-import { PAGE_ACCOUNT } from "@shopware-pwa/default-theme/helpers/pages"
+import { PAGE_ACCOUNT } from "@/helpers/pages"
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 
 export default {
   components: {

--- a/packages/default-theme/components/SwLanguageSwitcher.vue
+++ b/packages/default-theme/components/SwLanguageSwitcher.vue
@@ -19,7 +19,7 @@
 </template>
 <script>
 import { SfSelect } from "@storefront-ui/vue"
-import { useLocales } from "@shopware-pwa/default-theme/logic/useLocales"
+import { useLocales } from "@/logic/useLocales"
 
 export default {
   name: "SwLanguageSwitcher",

--- a/packages/default-theme/components/SwOrderDetails.vue
+++ b/packages/default-theme/components/SwOrderDetails.vue
@@ -92,8 +92,8 @@ import {
   getPaymentMethodDetails,
   getOrderPaymentUrl,
 } from "@shopware-pwa/shopware-6-client"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import { PAGE_ORDER_SUCCESS } from "@shopware-pwa/default-theme/helpers/pages"
+import SwButton from "@/components/atoms/SwButton"
+import { PAGE_ORDER_SUCCESS } from "@/helpers/pages"
 import SwOrderDetailsItem from "@/components/SwOrderDetailsItem"
 import SwPersonalDetails from "@/components/SwPersonalDetails"
 import SwAddress from "@/components/SwAddress"

--- a/packages/default-theme/components/SwProductCard.vue
+++ b/packages/default-theme/components/SwProductCard.vue
@@ -74,8 +74,7 @@ export default {
     },
     getImageUrl() {
       return (
-        getProductThumbnailUrl(this.product) ||
-        require("@shopware-pwa/default-theme/assets/productB.jpg")
+        getProductThumbnailUrl(this.product) || require("@/assets/productB.jpg")
       )
     },
   },

--- a/packages/default-theme/components/SwProductCardHorizontal.vue
+++ b/packages/default-theme/components/SwProductCardHorizontal.vue
@@ -70,8 +70,7 @@ export default {
     },
     getImageUrl() {
       return (
-        getProductMainImageUrl(this.product) ||
-        require("@shopware-pwa/default-theme/assets/productB.jpg")
+        getProductMainImageUrl(this.product) || require("@/assets/productB.jpg")
       )
     },
   },

--- a/packages/default-theme/components/SwProductCarousel.vue
+++ b/packages/default-theme/components/SwProductCarousel.vue
@@ -17,7 +17,7 @@
 <script>
 import { SfSection, SfCarousel } from "@storefront-ui/vue"
 import { getProducts } from "@shopware-pwa/shopware-6-client"
-import SwProductCard from "@shopware-pwa/default-theme/components/SwProductCard"
+import SwProductCard from "@/components/SwProductCard"
 
 export default {
   name: "SwProductCarousel",

--- a/packages/default-theme/components/SwProductDetails.vue
+++ b/packages/default-theme/components/SwProductDetails.vue
@@ -81,12 +81,12 @@ import {
   getProductReviews,
 } from "@shopware-pwa/helpers"
 import { useAddToCart } from "@shopware-pwa/composables"
-import SwProductHeading from "@shopware-pwa/default-theme/components/SwProductHeading"
-import SwProductSelect from "@shopware-pwa/default-theme/components/SwProductSelect"
-import SwProductColors from "@shopware-pwa/default-theme/components/SwProductColors"
+import SwProductHeading from "@/components/SwProductHeading"
+import SwProductSelect from "@/components/SwProductSelect"
+import SwProductColors from "@/components/SwProductColors"
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
 
-import SwProductTabs from "@shopware-pwa/default-theme/components/SwProductTabs"
+import SwProductTabs from "@/components/SwProductTabs"
 export default {
   name: "SwProductDetails",
 

--- a/packages/default-theme/components/SwProductListingFilters.vue
+++ b/packages/default-theme/components/SwProductListingFilters.vue
@@ -102,8 +102,8 @@ import {
 import { computed, ref } from "@vue/composition-api"
 
 import { useUIState, useListing } from "@shopware-pwa/composables"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import SwProductListingFilter from "@shopware-pwa/default-theme/components/listing/SwProductListingFilter"
+import SwButton from "@/components/atoms/SwButton"
+import SwProductListingFilter from "@/components/listing/SwProductListingFilter"
 
 export default {
   name: "CmsElementCategorySidebarFilter",

--- a/packages/default-theme/components/SwRegister.vue
+++ b/packages/default-theme/components/SwRegister.vue
@@ -151,8 +151,8 @@ import {
   getMessagesFromErrorsArray,
 } from "@shopware-pwa/helpers"
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwButton from "@/components/atoms/SwButton"
+import SwInput from "@/components/atoms/SwInput"
 
 export default {
   name: "SwResetPassword",

--- a/packages/default-theme/components/SwResetPassword.vue
+++ b/packages/default-theme/components/SwResetPassword.vue
@@ -41,8 +41,8 @@ import { SfAlert, SfHeading } from "@storefront-ui/vue"
 import { validationMixin } from "vuelidate"
 import { required, email } from "vuelidate/lib/validators"
 import { useUser } from "@shopware-pwa/composables"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwButton from "@/components/atoms/SwButton"
+import SwInput from "@/components/atoms/SwInput"
 
 export default {
   name: "SwResetPassword",

--- a/packages/default-theme/components/SwSearchBar.vue
+++ b/packages/default-theme/components/SwSearchBar.vue
@@ -22,7 +22,7 @@
 
 <script>
 import { ref, reactive, onMounted, watch, computed } from "@vue/composition-api"
-import { getSearchPageUrl } from "@shopware-pwa/default-theme/helpers"
+import { getSearchPageUrl } from "@/helpers"
 import { SfSearchBar } from "@storefront-ui/vue"
 import { useProductQuickSearch } from "@shopware-pwa/composables"
 import { debounce } from "@shopware-pwa/helpers"

--- a/packages/default-theme/components/SwSuggestSearch.vue
+++ b/packages/default-theme/components/SwSuggestSearch.vue
@@ -52,7 +52,7 @@ import {
   SfIcon,
 } from "@storefront-ui/vue"
 import { clickOutside } from "@storefront-ui/vue/src/utilities/directives"
-import Button from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import Button from "@/components/atoms/SwButton"
 import {
   getProductMainImageUrl,
   getProductRegularPrice,

--- a/packages/default-theme/components/SwTopBar.vue
+++ b/packages/default-theme/components/SwTopBar.vue
@@ -9,8 +9,8 @@
 
 <script>
 import { SfTopBar } from "@storefront-ui/vue"
-import SwCurrencySwitcher from "@shopware-pwa/default-theme/components/SwCurrencySwitcher"
-import SwLanguageSwitcher from "@shopware-pwa/default-theme/components/SwLanguageSwitcher"
+import SwCurrencySwitcher from "@/components/SwCurrencySwitcher"
+import SwLanguageSwitcher from "@/components/SwLanguageSwitcher"
 
 export default {
   components: {

--- a/packages/default-theme/components/SwTopNavigation.vue
+++ b/packages/default-theme/components/SwTopNavigation.vue
@@ -42,12 +42,12 @@
 <script>
 import { useNavigation, useUIState } from "@shopware-pwa/composables"
 
-import SwMegaMenu from "@shopware-pwa/default-theme/components/SwMegaMenu"
+import SwMegaMenu from "@/components/SwMegaMenu"
 import { ref, onMounted, watch } from "@vue/composition-api"
 import { getCategoryUrl } from "@shopware-pwa/helpers"
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import { useLocales } from "@shopware-pwa/default-theme/logic"
-import SwTopNavigationShowMore from "@shopware-pwa/default-theme/components/SwTopNavigationShowMore"
+import { useLocales } from "@/logic"
+import SwTopNavigationShowMore from "@/components/SwTopNavigationShowMore"
 
 export default {
   components: {

--- a/packages/default-theme/components/account/orders/Order.vue
+++ b/packages/default-theme/components/account/orders/Order.vue
@@ -40,9 +40,9 @@
 <script>
 import { SfTable } from "@storefront-ui/vue"
 import { useUser } from "@shopware-pwa/composables"
-import SwOrderDetails from "@shopware-pwa/default-theme/components/SwOrderDetails"
-import { formatDate, formatPrice } from "@shopware-pwa/default-theme/helpers"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwOrderDetails from "@/components/SwOrderDetails"
+import { formatDate, formatPrice } from "@/helpers"
+import SwButton from "@/components/atoms/SwButton"
 
 export default {
   name: "Order",

--- a/packages/default-theme/components/checkout/sidebar/SidebarOrderReview.vue
+++ b/packages/default-theme/components/checkout/sidebar/SidebarOrderReview.vue
@@ -47,11 +47,11 @@
 </template>
 <script>
 import { SfHeading, SfCircleIcon, SfCharacteristic } from "@storefront-ui/vue"
-import PersonalDetailsSummary from "@shopware-pwa/default-theme/components/checkout/summary/PersonalDetailsSummary"
-import ShippingAddressSummary from "@shopware-pwa/default-theme/components/checkout/summary/ShippingAddressSummary"
-import BillingAddressSummary from "@shopware-pwa/default-theme/components/checkout/summary/BillingAddressSummary"
-import PaymentMethodSummary from "@shopware-pwa/default-theme/components/checkout/summary/PaymentMethodSummary"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import PersonalDetailsSummary from "@/components/checkout/summary/PersonalDetailsSummary"
+import ShippingAddressSummary from "@/components/checkout/summary/ShippingAddressSummary"
+import BillingAddressSummary from "@/components/checkout/summary/BillingAddressSummary"
+import PaymentMethodSummary from "@/components/checkout/summary/PaymentMethodSummary"
+import SwInput from "@/components/atoms/SwInput"
 
 export default {
   name: "SidebarOrderReview",

--- a/packages/default-theme/components/checkout/sidebar/SidebarOrderSummary.vue
+++ b/packages/default-theme/components/checkout/sidebar/SidebarOrderSummary.vue
@@ -56,7 +56,7 @@ import {
   SfCharacteristic,
 } from "@storefront-ui/vue"
 import { useCart } from "@shopware-pwa/composables"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwInput from "@/components/atoms/SwInput"
 
 export default {
   name: "SidebarOrderSummary",

--- a/packages/default-theme/components/checkout/steps/OrderReviewStep.vue
+++ b/packages/default-theme/components/checkout/steps/OrderReviewStep.vue
@@ -40,13 +40,13 @@
 </template>
 
 <script>
-import PersonalDetailsSummary from "@shopware-pwa/default-theme/components/checkout/summary/PersonalDetailsSummary"
-import ShippingAddressSummary from "@shopware-pwa/default-theme/components/checkout/summary/ShippingAddressSummary"
-import BillingAddressSummary from "@shopware-pwa/default-theme/components/checkout/summary/BillingAddressSummary"
-import PaymentMethodSummary from "@shopware-pwa/default-theme/components/checkout/summary/PaymentMethodSummary"
-import OrderItemsTable from "@shopware-pwa/default-theme/components/checkout/summary/OrderItemsTable"
-import TotalsSummary from "@shopware-pwa/default-theme/components/checkout/summary/TotalsSummary"
-import SwCartProduct from "@shopware-pwa/default-theme/components/SwCartProduct"
+import PersonalDetailsSummary from "@/components/checkout/summary/PersonalDetailsSummary"
+import ShippingAddressSummary from "@/components/checkout/summary/ShippingAddressSummary"
+import BillingAddressSummary from "@/components/checkout/summary/BillingAddressSummary"
+import PaymentMethodSummary from "@/components/checkout/summary/PaymentMethodSummary"
+import OrderItemsTable from "@/components/checkout/summary/OrderItemsTable"
+import TotalsSummary from "@/components/checkout/summary/TotalsSummary"
+import SwCartProduct from "@/components/SwCartProduct"
 
 import { SfHeading, SfAccordion } from "@storefront-ui/vue"
 import { useCart } from "@shopware-pwa/composables"

--- a/packages/default-theme/components/checkout/steps/PaymentStep.vue
+++ b/packages/default-theme/components/checkout/steps/PaymentStep.vue
@@ -23,7 +23,7 @@
           :description="paymentMethod.description"
           class="sw-form__radio payment-method"
         >
-          <template #description="{description}">
+          <template #description="{ description }">
             <div class="sf-radio__description">
               <div class="payment_description">
                 <p>{{ description }}</p>
@@ -68,11 +68,11 @@
 </template>
 <script>
 import { SfHeading, SfRadio } from "@storefront-ui/vue"
-import BillingAddressGuestForm from "@shopware-pwa/default-theme/components/checkout/steps/guest/BillingAddressGuestForm"
-import BillingAddressUserForm from "@shopware-pwa/default-theme/components/checkout/steps/user/BillingAddressUserForm"
+import BillingAddressGuestForm from "@/components/checkout/steps/guest/BillingAddressGuestForm"
+import BillingAddressUserForm from "@/components/checkout/steps/user/BillingAddressUserForm"
 import { useCheckout, useSessionContext } from "@shopware-pwa/composables"
 import { onMounted, computed } from "@vue/composition-api"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
 
 export default {

--- a/packages/default-theme/components/checkout/steps/PersonalDetailsStep.vue
+++ b/packages/default-theme/components/checkout/steps/PersonalDetailsStep.vue
@@ -7,8 +7,8 @@
 <script>
 import { useCheckout } from "@shopware-pwa/composables"
 
-import PersonalDetailsGuestForm from "@shopware-pwa/default-theme/components/checkout/steps/guest/PersonalDetailsGuestForm"
-import PersonalDetailsUserForm from "@shopware-pwa/default-theme/components/checkout/steps/user/PersonalDetailsUserForm"
+import PersonalDetailsGuestForm from "@/components/checkout/steps/guest/PersonalDetailsGuestForm"
+import PersonalDetailsUserForm from "@/components/checkout/steps/user/PersonalDetailsUserForm"
 
 export default {
   name: "PersonalDetailsStep",

--- a/packages/default-theme/components/checkout/steps/ShippingStep.vue
+++ b/packages/default-theme/components/checkout/steps/ShippingStep.vue
@@ -24,7 +24,7 @@
           :description="shippingMethod.deliveryTime.translated.name"
           class="sw-form__radio shipping"
         >
-          <template #label="{label}">
+          <template #label="{ label }">
             <div class="sf-radio__label shipping__label">
               <div>{{ label }}</div>
               <div class="shipping__label-price">
@@ -32,7 +32,7 @@
               </div>
             </div>
           </template>
-          <template #description="{description}">
+          <template #description="{ description }">
             <div class="sf-radio__description shipping__description">
               <div class="shipping__delivery">
                 <p>{{ description }}</p>
@@ -76,14 +76,14 @@
 <script>
 import { SfHeading, SfRadio } from "@storefront-ui/vue"
 import { computed, onMounted } from "@vue/composition-api"
-import ShippingAddressGuestForm from "@shopware-pwa/default-theme/components/checkout/steps/guest/ShippingAddressGuestForm"
-import ShippingAddressUserForm from "@shopware-pwa/default-theme/components/checkout/steps/user/ShippingAddressUserForm"
+import ShippingAddressGuestForm from "@/components/checkout/steps/guest/ShippingAddressGuestForm"
+import ShippingAddressUserForm from "@/components/checkout/steps/user/ShippingAddressUserForm"
 import {
   useCheckout,
   useSessionContext,
   useCart,
 } from "@shopware-pwa/composables"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
 
 export default {

--- a/packages/default-theme/components/checkout/steps/guest/BillingAddressGuestForm.vue
+++ b/packages/default-theme/components/checkout/steps/guest/BillingAddressGuestForm.vue
@@ -121,9 +121,9 @@ import { validationMixin } from "vuelidate"
 import {
   usePaymentStep,
   usePaymentStepValidationRules,
-} from "@shopware-pwa/default-theme/logic/checkout/usePaymentStep"
+} from "@/logic/checkout/usePaymentStep"
 import { useCountries } from "@shopware-pwa/composables"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwInput from "@/components/atoms/SwInput"
 
 export default {
   name: "BillingAddressGuestForm",

--- a/packages/default-theme/components/checkout/steps/guest/PersonalDetailsGuestForm.vue
+++ b/packages/default-theme/components/checkout/steps/guest/PersonalDetailsGuestForm.vue
@@ -104,8 +104,8 @@
 <script>
 import { SfCheckbox, SfHeading, SfCharacteristic } from "@storefront-ui/vue"
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwButton from "@/components/atoms/SwButton"
+import SwInput from "@/components/atoms/SwInput"
 
 import { validationMixin } from "vuelidate"
 import {
@@ -128,8 +128,8 @@ import {
 import {
   usePersonalDetailsStep,
   usePersonalDetailsStepValidationRules,
-} from "@shopware-pwa/default-theme/logic/checkout/usePersonalDetailsStep"
-import SwErrorsList from "@shopware-pwa/default-theme/components/SwErrorsList"
+} from "@/logic/checkout/usePersonalDetailsStep"
+import SwErrorsList from "@/components/SwErrorsList"
 
 export default {
   name: "PersonalDetailsGuestForm",

--- a/packages/default-theme/components/checkout/steps/guest/ShippingAddressGuestForm.vue
+++ b/packages/default-theme/components/checkout/steps/guest/ShippingAddressGuestForm.vue
@@ -112,10 +112,10 @@ import { validationMixin } from "vuelidate"
 import {
   useShippingStep,
   useShippingStepValidationRules,
-} from "@shopware-pwa/default-theme/logic/checkout/useShippingStep"
+} from "@/logic/checkout/useShippingStep"
 import { useCountries, useCheckout } from "@shopware-pwa/composables"
 import { computed } from "@vue/composition-api"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwInput from "@/components/atoms/SwInput"
 
 export default {
   name: "ShippingAddressGuestForm",

--- a/packages/default-theme/components/checkout/steps/user/BillingAddressUserForm.vue
+++ b/packages/default-theme/components/checkout/steps/user/BillingAddressUserForm.vue
@@ -46,7 +46,7 @@
 <script>
 import { SfList, SfRadio, SfCheckbox } from "@storefront-ui/vue"
 import { useUser } from "@shopware-pwa/composables"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 import { ref } from "@vue/composition-api"
 
 export default {

--- a/packages/default-theme/components/checkout/steps/user/PersonalDetailsUserForm.vue
+++ b/packages/default-theme/components/checkout/steps/user/PersonalDetailsUserForm.vue
@@ -19,8 +19,8 @@
 </template>
 <script>
 import { SfHeading } from "@storefront-ui/vue"
-import SwPersonalInfo from "@shopware-pwa/default-theme/components/forms/SwPersonalInfo"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwPersonalInfo from "@/components/forms/SwPersonalInfo"
+import SwButton from "@/components/atoms/SwButton"
 
 export default {
   name: "ShippingAddressUserForm",

--- a/packages/default-theme/components/checkout/steps/user/ShippingAddressUserForm.vue
+++ b/packages/default-theme/components/checkout/steps/user/ShippingAddressUserForm.vue
@@ -51,9 +51,9 @@
 <script>
 import { SfList, SfRadio, SfCheckbox, SfModal } from "@storefront-ui/vue"
 import { useUser } from "@shopware-pwa/composables"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 import { ref, onMounted } from "@vue/composition-api"
-import SwAddressForm from "@shopware-pwa/default-theme/components/forms/SwAddressForm.vue"
+import SwAddressForm from "@/components/forms/SwAddressForm.vue"
 
 export default {
   name: "ShippingAddressUserForm",

--- a/packages/default-theme/components/checkout/summary/BillingAddressSummary.vue
+++ b/packages/default-theme/components/checkout/summary/BillingAddressSummary.vue
@@ -12,8 +12,8 @@
 </template>
 <script>
 import { useCheckout } from "@shopware-pwa/composables"
-import SwAddress from "@shopware-pwa/default-theme/components/SwAddress"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwAddress from "@/components/SwAddress"
+import SwButton from "@/components/atoms/SwButton"
 
 export default {
   name: "BillingAddressSummary",

--- a/packages/default-theme/components/checkout/summary/PaymentMethodSummary.vue
+++ b/packages/default-theme/components/checkout/summary/PaymentMethodSummary.vue
@@ -11,10 +11,10 @@
   </SwCheckoutMethod>
 </template>
 <script>
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 import { useSessionContext } from "@shopware-pwa/composables"
 import { computed } from "@vue/composition-api"
-import SwCheckoutMethod from "@shopware-pwa/default-theme/components/SwCheckoutMethod"
+import SwCheckoutMethod from "@/components/SwCheckoutMethod"
 export default {
   name: "PaymentMethodSummary",
   components: {

--- a/packages/default-theme/components/checkout/summary/PersonalDetailsSummary.vue
+++ b/packages/default-theme/components/checkout/summary/PersonalDetailsSummary.vue
@@ -11,12 +11,12 @@
   </SwPersonalDetails>
 </template>
 <script>
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import { usePersonalDetailsStep } from "@shopware-pwa/default-theme/logic/checkout/usePersonalDetailsStep"
-import { CHECKOUT_STEPS } from "@shopware-pwa/default-theme/logic/checkout"
+import SwButton from "@/components/atoms/SwButton"
+import { usePersonalDetailsStep } from "@/logic/checkout/usePersonalDetailsStep"
+import { CHECKOUT_STEPS } from "@/logic/checkout"
 import { useCheckout, useUser } from "@shopware-pwa/composables"
 import { computed } from "@vue/composition-api"
-import SwPersonalDetails from "@shopware-pwa/default-theme/components/SwPersonalDetails"
+import SwPersonalDetails from "@/components/SwPersonalDetails"
 
 export default {
   name: "PersonalDetailsSummary",

--- a/packages/default-theme/components/checkout/summary/ShippingAddressSummary.vue
+++ b/packages/default-theme/components/checkout/summary/ShippingAddressSummary.vue
@@ -15,9 +15,9 @@
   </SwAddress>
 </template>
 <script>
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 import { useSessionContext, useCheckout } from "@shopware-pwa/composables"
-import SwAddress from "@shopware-pwa/default-theme/components/SwAddress"
+import SwAddress from "@/components/SwAddress"
 
 export default {
   name: "ShippingAddressSummary",

--- a/packages/default-theme/components/checkout/summary/TotalsSummary.vue
+++ b/packages/default-theme/components/checkout/summary/TotalsSummary.vue
@@ -35,8 +35,8 @@
 </template>
 <script>
 import { useCart } from "@shopware-pwa/composables"
-import SwTotals from "@shopware-pwa/default-theme/components/SwTotals"
-import helpers from "@shopware-pwa/default-theme/helpers"
+import SwTotals from "@/components/SwTotals"
+import helpers from "@/helpers"
 
 import {
   SfProperty,
@@ -44,7 +44,7 @@ import {
   SfHeading,
   SfNotification,
 } from "@storefront-ui/vue"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 
 export default {
   name: "TotalsSummary",

--- a/packages/default-theme/components/forms/SwAddressForm.vue
+++ b/packages/default-theme/components/forms/SwAddressForm.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="sw-address">
-    <p class="message">
-      Keep your addresses and contact details updated.
-    </p>
+    <p class="message">Keep your addresses and contact details updated.</p>
     <SfAlert
       v-if="countriesError || userError"
       class="sw-personal-info__alert"
@@ -158,8 +156,8 @@ import {
   useSalutations,
 } from "@shopware-pwa/composables"
 import { mapCountries, mapSalutations } from "@shopware-pwa/helpers"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwButton from "@/components/atoms/SwButton"
+import SwInput from "@/components/atoms/SwInput"
 
 export default {
   name: "SwAddressForm",

--- a/packages/default-theme/components/forms/SwPassword.vue
+++ b/packages/default-theme/components/forms/SwPassword.vue
@@ -68,9 +68,9 @@ import { required, minLength, sameAs } from "vuelidate/lib/validators"
 import { computed } from "@vue/composition-api"
 import { useUser } from "@shopware-pwa/composables"
 import { getMessagesFromErrorsArray } from "@shopware-pwa/helpers"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
-import SwErrorsList from "@shopware-pwa/default-theme/components/SwErrorsList"
+import SwButton from "@/components/atoms/SwButton"
+import SwInput from "@/components/atoms/SwInput"
+import SwErrorsList from "@/components/SwErrorsList"
 
 export default {
   name: "SwPassword",

--- a/packages/default-theme/components/forms/SwPersonalInfo.vue
+++ b/packages/default-theme/components/forms/SwPersonalInfo.vue
@@ -77,7 +77,7 @@
             :color="updated ? 'green-primary' : 'gray-primary'"
             size="14px"
             icon="check"
-            style="margin-left: 10px;"
+            style="margin-left: 10px"
           />
         </slot>
       </div>
@@ -97,9 +97,9 @@ import {
 import { SfIcon } from "@storefront-ui/vue"
 import { useUser } from "@shopware-pwa/composables"
 import { getMessagesFromErrorsArray } from "@shopware-pwa/helpers"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
-import SwErrorsList from "@shopware-pwa/default-theme/components/SwErrorsList"
+import SwButton from "@/components/atoms/SwButton"
+import SwInput from "@/components/atoms/SwInput"
+import SwErrorsList from "@/components/SwErrorsList"
 
 export default {
   name: "SwPersonalInfo",

--- a/packages/default-theme/components/listing/types/max.vue
+++ b/packages/default-theme/components/listing/types/max.vue
@@ -13,12 +13,8 @@
 import { computed, ref } from "@vue/composition-api"
 
 const maxMap = {
-  "shipping-free": () =>
-    import(
-      `@shopware-pwa/default-theme/components/listing/types/shipping-free.vue`
-    ),
-  rating: () =>
-    import(`@shopware-pwa/default-theme/components/listing/types/rating.vue`),
+  "shipping-free": () => import(`@/components/listing/types/shipping-free.vue`),
+  rating: () => import(`@/components/listing/types/rating.vue`),
 }
 
 export default {

--- a/packages/default-theme/components/listing/types/range.vue
+++ b/packages/default-theme/components/listing/types/range.vue
@@ -25,7 +25,7 @@
 import { computed, ref } from "@vue/composition-api"
 
 import { SfFilter, SfHeading } from "@storefront-ui/vue"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwInput from "@/components/atoms/SwInput"
 import { validationMixin } from "vuelidate"
 import { required, email } from "vuelidate/lib/validators"
 

--- a/packages/default-theme/components/listing/types/rating.vue
+++ b/packages/default-theme/components/listing/types/rating.vue
@@ -14,7 +14,7 @@
 <script>
 import { computed, ref } from "@vue/composition-api"
 import { SfRating, SfIcon, SfHeading } from "@storefront-ui/vue"
-import SwRating from "@shopware-pwa/default-theme/components/atoms/SwRating"
+import SwRating from "@/components/atoms/SwRating"
 
 export default {
   components: {

--- a/packages/default-theme/components/listing/types/shipping-free.vue
+++ b/packages/default-theme/components/listing/types/shipping-free.vue
@@ -17,7 +17,7 @@
 import { computed, ref } from "@vue/composition-api"
 
 import { SfFilter, SfCheckbox, SfHeading } from "@storefront-ui/vue"
-import SwInput from "@shopware-pwa/default-theme/components/atoms/SwInput"
+import SwInput from "@/components/atoms/SwInput"
 
 export default {
   name: "SwFilterShippingFree",

--- a/packages/default-theme/components/modals/SwLoginModal.vue
+++ b/packages/default-theme/components/modals/SwLoginModal.vue
@@ -62,12 +62,10 @@
 <script>
 import { SfHeading, SfModal, SfAlert } from "@storefront-ui/vue"
 import { useUser, useUIState } from "@shopware-pwa/composables"
-import SwLogin from "@shopware-pwa/default-theme/components/SwLogin"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
-const SwRegister = () =>
-  import("@shopware-pwa/default-theme/components/SwRegister")
-const SwResetPassword = () =>
-  import("@shopware-pwa/default-theme/components/SwResetPassword")
+import SwLogin from "@/components/SwLogin"
+import SwButton from "@/components/atoms/SwButton"
+const SwRegister = () => import("@/components/SwRegister")
+const SwResetPassword = () => import("@/components/SwResetPassword")
 
 export default {
   name: "SwLoginModal",

--- a/packages/default-theme/components/views/ProductView.vue
+++ b/packages/default-theme/components/views/ProductView.vue
@@ -52,11 +52,11 @@
 <script>
 import { SfImage, SfSection } from "@storefront-ui/vue"
 import { useProduct } from "@shopware-pwa/composables"
-import SwGoBackArrow from "@shopware-pwa/default-theme/components/atoms/SwGoBackArrow"
-import SwProductGallery from "@shopware-pwa/default-theme/components/SwProductGallery"
-import SwProductDetails from "@shopware-pwa/default-theme/components/SwProductDetails"
-import SwProductCarousel from "@shopware-pwa/default-theme/components/SwProductCarousel"
-import SwProductAdvertisement from "@shopware-pwa/default-theme/components/SwProductAdvertisement"
+import SwGoBackArrow from "@/components/atoms/SwGoBackArrow"
+import SwProductGallery from "@/components/SwProductGallery"
+import SwProductDetails from "@/components/SwProductDetails"
+import SwProductCarousel from "@/components/SwProductCarousel"
+import SwProductAdvertisement from "@/components/SwProductAdvertisement"
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
 
 export default {

--- a/packages/default-theme/layouts/default.vue
+++ b/packages/default-theme/layouts/default.vue
@@ -32,16 +32,16 @@
 
 <script>
 import { SfBreadcrumbs } from "@storefront-ui/vue"
-import SwHeader from "@shopware-pwa/default-theme/components/SwHeader"
-import SwBottomNavigation from "@shopware-pwa/default-theme/components/SwBottomNavigation"
-import SwFooter from "@shopware-pwa/default-theme/components/SwFooter"
+import SwHeader from "@/components/SwHeader"
+import SwBottomNavigation from "@/components/SwBottomNavigation"
+import SwFooter from "@/components/SwFooter"
 import SwPluginSlot from "sw-plugins/SwPluginSlot"
 import { useCms, useUIState } from "@shopware-pwa/composables"
 import { computed, ref, watchEffect } from "@vue/composition-api"
-import SwLoginModal from "@shopware-pwa/default-theme/components/modals/SwLoginModal"
-import SwNotifications from "@shopware-pwa/default-theme/components/SwNotifications"
-import SwOfflineMode from "@shopware-pwa/default-theme/components/SwOfflineMode"
-const SwCart = () => import("@shopware-pwa/default-theme/components/SwCart")
+import SwLoginModal from "@/components/modals/SwLoginModal"
+import SwNotifications from "@/components/SwNotifications"
+import SwOfflineMode from "@/components/SwOfflineMode"
+const SwCart = () => import("@/components/SwCart")
 
 export default {
   components: {

--- a/packages/default-theme/layouts/error.vue
+++ b/packages/default-theme/layouts/error.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="error-page">
-    <SfImage
-      class="error-page__image"
-      :src="require('@shopware-pwa/default-theme/assets/error.svg')"
-    />
+    <SfImage class="error-page__image" :src="require('@/assets/error.svg')" />
     <SfHeading
       class="error-page__heading"
       :level="1"
@@ -33,7 +30,7 @@
 </template>
 <script>
 import { SfHeading, SfIcon, SfImage } from "@storefront-ui/vue"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 
 const customMessageDictionary = {
   404: "We can't find what you are looking for. Are you lost?",

--- a/packages/default-theme/logic/checkout/helpers.js
+++ b/packages/default-theme/logic/checkout/helpers.js
@@ -1,4 +1,4 @@
-import { CHECKOUT_STEPS } from "@shopware-pwa/default-theme/logic/checkout/steps"
+import { CHECKOUT_STEPS } from "@/logic/checkout/steps"
 
 export const getStepByNumber = (number) => {
   for (let [key, value] of Object.entries(CHECKOUT_STEPS)) {

--- a/packages/default-theme/logic/checkout/index.js
+++ b/packages/default-theme/logic/checkout/index.js
@@ -1,3 +1,3 @@
-export * from "@shopware-pwa/default-theme/logic/checkout/steps"
-export * from "@shopware-pwa/default-theme/logic/checkout/helpers"
-export * from "@shopware-pwa/default-theme/logic/checkout/useUICheckoutPage"
+export * from "@/logic/checkout/steps"
+export * from "@/logic/checkout/helpers"
+export * from "@/logic/checkout/useUICheckoutPage"

--- a/packages/default-theme/logic/checkout/usePaymentStep.js
+++ b/packages/default-theme/logic/checkout/usePaymentStep.js
@@ -1,6 +1,6 @@
 import { requiredIf } from "vuelidate/lib/validators"
 import { createCheckoutStep } from "@shopware-pwa/composables"
-import { CHECKOUT_STEPS } from "@shopware-pwa/default-theme/logic/checkout"
+import { CHECKOUT_STEPS } from "@/logic/checkout"
 
 export const usePaymentStep = createCheckoutStep({
   stepNumber: CHECKOUT_STEPS.PAYMENT,

--- a/packages/default-theme/logic/checkout/usePersonalDetailsStep.js
+++ b/packages/default-theme/logic/checkout/usePersonalDetailsStep.js
@@ -1,6 +1,6 @@
 import { required } from "vuelidate/lib/validators"
 import { createCheckoutStep } from "@shopware-pwa/composables"
-import { CHECKOUT_STEPS } from "@shopware-pwa/default-theme/logic/checkout"
+import { CHECKOUT_STEPS } from "@/logic/checkout"
 
 export const usePersonalDetailsStep = createCheckoutStep({
   stepNumber: CHECKOUT_STEPS.PERSONAL_DETAILS,

--- a/packages/default-theme/logic/checkout/useShippingStep.js
+++ b/packages/default-theme/logic/checkout/useShippingStep.js
@@ -1,6 +1,6 @@
 import { required } from "vuelidate/lib/validators"
 import { createCheckoutStep } from "@shopware-pwa/composables"
-import { CHECKOUT_STEPS } from "@shopware-pwa/default-theme/logic/checkout"
+import { CHECKOUT_STEPS } from "@/logic/checkout"
 
 export const useShippingStep = createCheckoutStep({
   stepNumber: CHECKOUT_STEPS.SHIPPING,

--- a/packages/default-theme/logic/checkout/useUICheckoutPage.js
+++ b/packages/default-theme/logic/checkout/useUICheckoutPage.js
@@ -1,11 +1,11 @@
 import { ref, computed } from "@vue/composition-api"
-import { CHECKOUT_STEPS } from "@shopware-pwa/default-theme/logic/checkout/steps"
-import { getStepByNumber } from "@shopware-pwa/default-theme/logic/checkout/helpers"
+import { CHECKOUT_STEPS } from "@/logic/checkout/steps"
+import { getStepByNumber } from "@/logic/checkout/helpers"
 import { useCheckout, getApplicationContext } from "@shopware-pwa/composables"
-import { usePersonalDetailsStep } from "@shopware-pwa/default-theme/logic/checkout/usePersonalDetailsStep"
-import { useShippingStep } from "@shopware-pwa/default-theme/logic/checkout/useShippingStep"
-import { usePaymentStep } from "@shopware-pwa/default-theme/logic/checkout/usePaymentStep"
-import { PAGE_ORDER_SUCCESS } from "@shopware-pwa/default-theme/helpers/pages"
+import { usePersonalDetailsStep } from "@/logic/checkout/usePersonalDetailsStep"
+import { useShippingStep } from "@/logic/checkout/useShippingStep"
+import { usePaymentStep } from "@/logic/checkout/usePaymentStep"
+import { PAGE_ORDER_SUCCESS } from "@/helpers/pages"
 
 export const useUICheckoutPage = (rootContext) => {
   const { router, i18n } = getApplicationContext(

--- a/packages/default-theme/middleware/auth.js
+++ b/packages/default-theme/middleware/auth.js
@@ -1,5 +1,5 @@
 import { useUser } from "@shopware-pwa/composables"
-import { PAGE_LOGIN } from "@shopware-pwa/default-theme/helpers/pages"
+import { PAGE_LOGIN } from "@/helpers/pages"
 const LOGIN_ROUTE_NAME = "login"
 
 const PAGES_FOR_LOGGED_IN_ONLY = [

--- a/packages/default-theme/pages/_.vue
+++ b/packages/default-theme/pages/_.vue
@@ -1,4 +1,4 @@
 <script>
-import Pages from "@shopware-pwa/default-theme/pages/_lang/_"
+import Pages from "@/pages/_lang/_"
 export default Pages
 </script>

--- a/packages/default-theme/pages/_lang/_.vue
+++ b/packages/default-theme/pages/_lang/_.vue
@@ -8,10 +8,8 @@ import { useCms, useNotifications } from "@shopware-pwa/composables"
 import languagesMap from "sw-plugins/languages"
 
 const pagesMap = {
-  "frontend.navigation.page": () =>
-    import("@shopware-pwa/default-theme/components/views/CategoryView"),
-  "frontend.detail.page": () =>
-    import("@shopware-pwa/default-theme/components/views/ProductView"),
+  "frontend.navigation.page": () => import("@/components/views/CategoryView"),
+  "frontend.detail.page": () => import("@/components/views/ProductView"),
 }
 
 export function getComponentBy(resourceType) {

--- a/packages/default-theme/pages/_lang/account.vue
+++ b/packages/default-theme/pages/_lang/account.vue
@@ -28,9 +28,9 @@
 import { computed } from "@vue/composition-api"
 import { SfContentPages } from "@storefront-ui/vue"
 import { useUser } from "@shopware-pwa/composables"
-import { PAGE_LOGIN } from "@shopware-pwa/default-theme/helpers/pages"
+import { PAGE_LOGIN } from "@/helpers/pages"
 
-import authMiddleware from "@shopware-pwa/default-theme/middleware/auth"
+import authMiddleware from "@/middleware/auth"
 
 export default {
   name: "AccountPage",
@@ -62,7 +62,7 @@ export default {
       return (this.user && this.user && this.user.activeShippingAddress) || {}
     },
   },
-  
+
   watch: {
     $route(to, from) {
       if (to.name === "account-profile") {

--- a/packages/default-theme/pages/_lang/account/addresses/add/_id.vue
+++ b/packages/default-theme/pages/_lang/account/addresses/add/_id.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import SwAddressForm from "@shopware-pwa/default-theme/components/forms/SwAddressForm.vue"
+import SwAddressForm from "@/components/forms/SwAddressForm.vue"
 import { useUser } from "@shopware-pwa/composables"
 
 export default {

--- a/packages/default-theme/pages/_lang/account/addresses/add/index.vue
+++ b/packages/default-theme/pages/_lang/account/addresses/add/index.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import SwAddressForm from "@shopware-pwa/default-theme/components/forms/SwAddressForm.vue"
+import SwAddressForm from "@/components/forms/SwAddressForm.vue"
 
 export default {
   components: { SwAddressForm },

--- a/packages/default-theme/pages/_lang/account/addresses/index.vue
+++ b/packages/default-theme/pages/_lang/account/addresses/index.vue
@@ -23,8 +23,8 @@
 </template>
 
 <script>
-import SwAddressList from "@shopware-pwa/default-theme/components/SwAddressList.vue"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwAddressList from "@/components/SwAddressList.vue"
+import SwButton from "@/components/atoms/SwButton"
 import { SfTabs } from "@storefront-ui/vue"
 export default {
   name: "MyAddresses",

--- a/packages/default-theme/pages/_lang/account/orders/_id.vue
+++ b/packages/default-theme/pages/_lang/account/orders/_id.vue
@@ -7,7 +7,7 @@
 
 <script>
 import { SfHeading } from "@storefront-ui/vue"
-import SwOrderDetails from "@shopware-pwa/default-theme/components/SwOrderDetails"
+import SwOrderDetails from "@/components/SwOrderDetails"
 
 export default {
   components: { SfHeading, SwOrderDetails },

--- a/packages/default-theme/pages/_lang/account/orders/index.vue
+++ b/packages/default-theme/pages/_lang/account/orders/index.vue
@@ -27,7 +27,7 @@
 <script>
 import { SfTabs, SfTable } from "@storefront-ui/vue"
 import { useUser } from "@shopware-pwa/composables"
-import Order from "@shopware-pwa/default-theme/components/account/orders/Order"
+import Order from "@/components/account/orders/Order"
 
 export default {
   name: "OrderHistory",

--- a/packages/default-theme/pages/_lang/account/profile.vue
+++ b/packages/default-theme/pages/_lang/account/profile.vue
@@ -11,7 +11,7 @@
     </SfTab>
     <SfTab title="Password change">
       <SwPassword>
-        <template #message="{user}">
+        <template #message="{ user }">
           <p class="message">
             If you want to change the password to access your account, enter the
             following information:<br />Your current email address is
@@ -25,8 +25,8 @@
 
 <script>
 import { SfTabs } from "@storefront-ui/vue"
-import SwPassword from "@shopware-pwa/default-theme/components/forms/SwPassword"
-import SwPersonalInfo from "@shopware-pwa/default-theme/components/forms/SwPersonalInfo"
+import SwPassword from "@/components/forms/SwPassword"
+import SwPersonalInfo from "@/components/forms/SwPersonalInfo"
 
 export default {
   name: "MyProfile",

--- a/packages/default-theme/pages/_lang/checkout.vue
+++ b/packages/default-theme/pages/_lang/checkout.vue
@@ -46,16 +46,13 @@
 </template>
 <script>
 import { SfSteps } from "@storefront-ui/vue"
-import SidebarOrderReview from "@shopware-pwa/default-theme/components/checkout/sidebar/SidebarOrderReview"
-import SidebarOrderSummary from "@shopware-pwa/default-theme/components/checkout/sidebar/SidebarOrderSummary"
-import PaymentStep from "@shopware-pwa/default-theme/components/checkout/steps/PaymentStep"
-import PersonalDetailsStep from "@shopware-pwa/default-theme/components/checkout/steps/PersonalDetailsStep"
-import ShippingStep from "@shopware-pwa/default-theme/components/checkout/steps/ShippingStep"
-import OrderReviewStep from "@shopware-pwa/default-theme/components/checkout/steps/OrderReviewStep"
-import {
-  CHECKOUT_STEPS,
-  useUICheckoutPage,
-} from "@shopware-pwa/default-theme/logic/checkout"
+import SidebarOrderReview from "@/components/checkout/sidebar/SidebarOrderReview"
+import SidebarOrderSummary from "@/components/checkout/sidebar/SidebarOrderSummary"
+import PaymentStep from "@/components/checkout/steps/PaymentStep"
+import PersonalDetailsStep from "@/components/checkout/steps/PersonalDetailsStep"
+import ShippingStep from "@/components/checkout/steps/ShippingStep"
+import OrderReviewStep from "@/components/checkout/steps/OrderReviewStep"
+import { CHECKOUT_STEPS, useUICheckoutPage } from "@/logic/checkout"
 
 export default {
   name: "CheckoutPage",

--- a/packages/default-theme/pages/_lang/login.vue
+++ b/packages/default-theme/pages/_lang/login.vue
@@ -11,9 +11,9 @@
 <script>
 import { SfHeading } from "@storefront-ui/vue"
 
-import SwLogin from "@shopware-pwa/default-theme/components/SwLogin"
-import { PAGE_ACCOUNT } from "@shopware-pwa/default-theme/helpers/pages"
-import authMiddleware from "@shopware-pwa/default-theme/middleware/auth"
+import SwLogin from "@/components/SwLogin"
+import { PAGE_ACCOUNT } from "@/helpers/pages"
+import authMiddleware from "@/middleware/auth"
 
 export default {
   name: "LoginPage",

--- a/packages/default-theme/pages/_lang/order.vue
+++ b/packages/default-theme/pages/_lang/order.vue
@@ -15,9 +15,9 @@
 <script>
 import { SfHeading, SfIcon, SfDivider } from "@storefront-ui/vue"
 import { computed } from "@vue/composition-api"
-import SwButton from "@shopware-pwa/default-theme/components/atoms/SwButton"
+import SwButton from "@/components/atoms/SwButton"
 
-import SwOrderDetails from "@shopware-pwa/default-theme/components/SwOrderDetails"
+import SwOrderDetails from "@/components/SwOrderDetails"
 
 export default {
   name: "OrderPage",

--- a/packages/default-theme/pages/account.vue
+++ b/packages/default-theme/pages/account.vue
@@ -1,4 +1,4 @@
 <script>
-import Account from "@shopware-pwa/default-theme/pages/_lang/account"
+import Account from "@/pages/_lang/account"
 export default Account
 </script>

--- a/packages/default-theme/pages/account/addresses.vue
+++ b/packages/default-theme/pages/account/addresses.vue
@@ -1,4 +1,4 @@
 <script>
-import Addresses from "@shopware-pwa/default-theme/pages/_lang/account/addresses"
+import Addresses from "@/pages/_lang/account/addresses"
 export default Addresses
 </script>

--- a/packages/default-theme/pages/account/addresses/add/_id.vue
+++ b/packages/default-theme/pages/account/addresses/add/_id.vue
@@ -1,4 +1,4 @@
 <script>
-import AddAddress from "@shopware-pwa/default-theme/pages/_lang/account/addresses/add/_id"
+import AddAddress from "@/pages/_lang/account/addresses/add/_id"
 export default AddAddress
 </script>

--- a/packages/default-theme/pages/account/addresses/add/index.vue
+++ b/packages/default-theme/pages/account/addresses/add/index.vue
@@ -1,4 +1,4 @@
 <script>
-import Add from "@shopware-pwa/default-theme/pages/_lang/account/addresses/add/index"
+import Add from "@/pages/_lang/account/addresses/add/index"
 export default Add
 </script>

--- a/packages/default-theme/pages/account/addresses/index.vue
+++ b/packages/default-theme/pages/account/addresses/index.vue
@@ -1,4 +1,4 @@
 <script>
-import Addresses from "@shopware-pwa/default-theme/pages/_lang/account/addresses/index"
+import Addresses from "@/pages/_lang/account/addresses/index"
 export default Addresses
 </script>

--- a/packages/default-theme/pages/account/orders.vue
+++ b/packages/default-theme/pages/account/orders.vue
@@ -1,4 +1,4 @@
 <script>
-import Orders from "@shopware-pwa/default-theme/pages/_lang/account/orders"
+import Orders from "@/pages/_lang/account/orders"
 export default Orders
 </script>

--- a/packages/default-theme/pages/account/orders/_id.vue
+++ b/packages/default-theme/pages/account/orders/_id.vue
@@ -1,4 +1,4 @@
 <script>
-import OrderView from "@shopware-pwa/default-theme/pages/_lang/account/orders/_id"
+import OrderView from "@/pages/_lang/account/orders/_id"
 export default OrderView
 </script>

--- a/packages/default-theme/pages/account/orders/index.vue
+++ b/packages/default-theme/pages/account/orders/index.vue
@@ -1,4 +1,4 @@
 <script>
-import OrderList from "@shopware-pwa/default-theme/pages/_lang/account/orders/index"
+import OrderList from "@/pages/_lang/account/orders/index"
 export default OrderList
 </script>

--- a/packages/default-theme/pages/account/profile.vue
+++ b/packages/default-theme/pages/account/profile.vue
@@ -1,4 +1,4 @@
 <script>
-import Profile from "@shopware-pwa/default-theme/pages/_lang/account/profile"
+import Profile from "@/pages/_lang/account/profile"
 export default Profile
 </script>

--- a/packages/default-theme/pages/checkout.vue
+++ b/packages/default-theme/pages/checkout.vue
@@ -1,4 +1,4 @@
 <script>
-import Checkout from "@shopware-pwa/default-theme/pages/_lang/checkout"
+import Checkout from "@/pages/_lang/checkout"
 export default Checkout
 </script>

--- a/packages/default-theme/pages/login.vue
+++ b/packages/default-theme/pages/login.vue
@@ -1,4 +1,4 @@
 <script>
-import Login from "@shopware-pwa/default-theme/pages/_lang/login"
+import Login from "@/pages/_lang/login"
 export default Login
 </script>

--- a/packages/default-theme/pages/order.vue
+++ b/packages/default-theme/pages/order.vue
@@ -1,4 +1,4 @@
 <script>
-import SuccessPage from "@shopware-pwa/default-theme/pages/_lang/order"
+import SuccessPage from "@/pages/_lang/order"
 export default SuccessPage
 </script>

--- a/packages/default-theme/pages/search.vue
+++ b/packages/default-theme/pages/search.vue
@@ -1,4 +1,4 @@
 <script>
-import Search from "@shopware-pwa/default-theme/pages/_lang/search"
+import Search from "@/pages/_lang/search"
 export default Search
 </script>

--- a/packages/nuxt-module/plugins/price-filter.js
+++ b/packages/nuxt-module/plugins/price-filter.js
@@ -1,7 +1,7 @@
 import Vue from "vue";
 import { provide } from "@vue/composition-api";
 import { useCurrency } from "@shopware-pwa/composables";
-import { formatPrice } from "@shopware-pwa/default-theme/helpers";
+import { formatPrice } from "@/helpers";
 
 export default ({ app }) => {
   app.setup = () => {


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->

related: #1040 

Changes all component aliases from `@shopware-pwa/default-theme` to `@`

<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [x] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
