### PR TITLE
feat: ability to use another theme

### DIFF
--- a/packages/cli/src/commands/cms.ts
+++ b/packages/cli/src/commands/cms.ts
@@ -7,7 +7,9 @@ module.exports = {
   run: async (toolbox: GluegunToolbox) => {
     const path = require("path");
 
-    const mainCmsPath = path.join(toolbox.defaultThemeLocation, "cms");
+    toolbox.checkThemePath();
+
+    const mainCmsPath = path.join(toolbox.getThemePath(), "cms");
 
     const swCmsPath = path.join(".shopware-pwa", "sw-cms");
     const swPluginsPath = path.join(".shopware-pwa", "pwa-bundles-assets");

--- a/packages/cli/src/commands/languages.ts
+++ b/packages/cli/src/commands/languages.ts
@@ -13,6 +13,8 @@ module.exports = {
   hidden: true,
   run: async (toolbox: GluegunToolbox) => {
     const path = require("path");
+    toolbox.checkThemePath();
+
     const inputParameters = toolbox.inputParameters;
     const shopwarePwaPath = path.join(".shopware-pwa", "sw-plugins");
     const shopwarePwaLocalesPath = path.join(
@@ -21,10 +23,7 @@ module.exports = {
       "locales"
     );
 
-    const themeLanguagesDir = path.join(
-      toolbox.defaultThemeLocation,
-      "locales"
-    );
+    const themeLanguagesDir = path.join(toolbox.getThemePath(), "locales");
 
     /**
      * -> Create results map

--- a/packages/cli/src/commands/override.ts
+++ b/packages/cli/src/commands/override.ts
@@ -32,7 +32,10 @@ module.exports = {
     "Allows you to override theme component. Component will appear in project ready to be edited.",
   run: async (toolbox: GluegunToolbox) => {
     const path = require("path");
-    const directoryPath = path.join(toolbox.defaultThemeLocation, "components");
+
+    toolbox.checkThemePath();
+
+    const directoryPath = path.join(toolbox.getThemePath(), "components");
 
     const componentsFullPaths = getAllFiles(directoryPath);
     const themeComponents = componentsFullPaths.map((path) =>

--- a/packages/cli/src/extensions/nuxt-extension.ts
+++ b/packages/cli/src/extensions/nuxt-extension.ts
@@ -34,6 +34,7 @@ module.exports = (toolbox: GluegunToolbox) => {
       target: "server",
       devTools: [],
       gitUsername: "",
+      ci: "none",
     };
     if (!isNuxtGenerated) {
       const nuxtGenerate = `npx --ignore-existing create-nuxt-app@3.2.0 --answers "${JSON.stringify(

--- a/packages/cli/src/extensions/nuxt-extension.ts
+++ b/packages/cli/src/extensions/nuxt-extension.ts
@@ -284,8 +284,8 @@ module.exports = (toolbox: GluegunToolbox) => {
     const dest = destination ? destination : folderName;
     const destinationExist = toolbox.filesystem.existsAsync(dest);
     if (destinationExist) return;
-    await toolbox.filesystem.copyAsync(
-      path.join(toolbox.defaultThemeLocation, folderName),
+    toolbox.filesystem.copyAsync(
+      path.join(toolbox.getThemePath(), folderName),
       dest,
       { overwrite: true }
     );

--- a/packages/cli/src/extensions/nuxt-extension.ts
+++ b/packages/cli/src/extensions/nuxt-extension.ts
@@ -284,7 +284,7 @@ module.exports = (toolbox: GluegunToolbox) => {
     const dest = destination ? destination : folderName;
     const destinationExist = toolbox.filesystem.existsAsync(dest);
     if (destinationExist) return;
-    toolbox.filesystem.copyAsync(
+    return toolbox.filesystem.copyAsync(
       path.join(toolbox.getThemePath(), folderName),
       dest,
       { overwrite: true }

--- a/packages/cli/src/extensions/shopware-pwa-extension.ts
+++ b/packages/cli/src/extensions/shopware-pwa-extension.ts
@@ -30,7 +30,7 @@ module.exports = (toolbox: GluegunToolbox) => {
     const nodePackagePathExist = require("fs").existsSync(nodePackagePath);
     if (nodePackagePathExist) return nodePackagePath;
 
-    throw `No theme found for "${directPath}". Please make sure that path is correct or theme is installed from NPM.`;
+    throw new Error(`No theme found for "${directPath}". Please make sure that path is correct or theme is installed from NPM.`);
   };
 
   toolbox.checkThemePath = () => {

--- a/packages/cli/src/extensions/shopware-pwa-extension.ts
+++ b/packages/cli/src/extensions/shopware-pwa-extension.ts
@@ -3,6 +3,7 @@ import { GluegunToolbox } from "gluegun";
 const defaultConfig = {
   shopwareEndpoint: "https://pwa-demo-api.shopware.com",
   shopwareAccessToken: "SWSC40-LJTNO6COUEN7CJMXKLA",
+  theme: "@shopware-pwa/default-theme",
 };
 // add your CLI-specific functionality here, which will then be accessible
 // to your commands
@@ -13,7 +14,34 @@ module.exports = (toolbox: GluegunToolbox) => {
 
   toolbox.themeFolders = [".eslintrc.js"];
 
-  toolbox.defaultThemeLocation = `node_modules/@shopware-pwa/default-theme`;
+  /**
+   * Project theme can be placed in one of the places
+   * 1. direct relative path to project root folder ex. `./my-theme` directory and `theme: "my-theme"` setting in shopware-pwa.config.js
+   * 2. in node_modules directory, like base theme ex. `theme: "@shopware-pwa/default-theme"` setting in shopware-pwa.config.js
+   */
+  toolbox.getThemePath = () => {
+    const path = require("path");
+
+    const directPath = toolbox.config.theme;
+    const directPathExist = require("fs").existsSync(directPath);
+    if (directPathExist) return directPath;
+
+    const nodePackagePath = path.join("node_modules", toolbox.config.theme);
+    const nodePackagePathExist = require("fs").existsSync(nodePackagePath);
+    if (nodePackagePathExist) return nodePackagePath;
+
+    throw `No theme found for "${directPath}". Please make sure that path is correct or theme is installed from NPM.`;
+  };
+
+  toolbox.checkThemePath = () => {
+    try {
+      toolbox.getThemePath();
+    } catch (e) {
+      toolbox.print.error(e);
+      process.exit(1);
+    }
+  };
+
   // enable this if you want to read configuration in from
   // the current folder's package.json (in a "shopware-pwa" property),
   // shopware-pwa.config.json, etc.

--- a/packages/nuxt-module/__tests__/extendCms.spec.ts
+++ b/packages/nuxt-module/__tests__/extendCms.spec.ts
@@ -1,6 +1,7 @@
 import { extendCMS } from "../src/cms";
 import jetpack from "fs-jetpack";
 import path from "path";
+import { ShopwarePwaConfigFile } from "../src/interfaces";
 
 jest.mock("fs-jetpack");
 const mockedJetpack = jetpack as jest.Mocked<typeof jetpack>;
@@ -25,6 +26,11 @@ describe("nuxt-module - extendCMS", () => {
     addPlugin: jest.fn(),
     extendBuild: (method: Function): number => methods.push(method),
   };
+  const mockedConfig: ShopwarePwaConfigFile = {
+    shopwareAccessToken: "qwe",
+    shopwareEndpoint: "http://localhost:3000/",
+    theme: "mocked-theme",
+  };
   /**
    * To resolve extendBuild we need to invoke resolveBuilds after method
    * invocation to test real impact on webpack configuration
@@ -45,14 +51,14 @@ describe("nuxt-module - extendCMS", () => {
 
   it("should throw an exception when cmsNameMapper.js is not created", () => {
     mockedJetpack.exists.mockReturnValueOnce(false);
-    expect(() => extendCMS(moduleObject)).toThrow(
+    expect(() => extendCMS(moduleObject, mockedConfig)).toThrow(
       "[shopware-pwa] CMS module is not initialized properly, please run 'shopware-pwa init'"
     );
   });
 
   it("should add global alias for sw-cms", () => {
     mockedJetpack.list.mockReturnValueOnce([]);
-    extendCMS(moduleObject);
+    extendCMS(moduleObject, mockedConfig);
     resolveBuilds();
     expect(webpackConfig.resolve.alias).toEqual({
       [`sw-cms`]: path.join(__dirname, ".shopware-pwa", "sw-cms"),
@@ -61,7 +67,7 @@ describe("nuxt-module - extendCMS", () => {
 
   it("should add global alias for sw-cms if there are no cms files found", () => {
     mockedJetpack.list.mockReturnValueOnce(undefined);
-    extendCMS(moduleObject);
+    extendCMS(moduleObject, mockedConfig);
     resolveBuilds();
     expect(webpackConfig.resolve.alias).toEqual({
       [`sw-cms`]: path.join(__dirname, ".shopware-pwa", "sw-cms"),
@@ -74,17 +80,10 @@ describe("nuxt-module - extendCMS", () => {
       "otherFile.txt",
     ]);
 
-    extendCMS(moduleObject);
+    extendCMS(moduleObject, mockedConfig);
     resolveBuilds();
     expect(webpackConfig.resolve.alias["sw-cms/SomeComponent"]).toContain(
-      path.join(
-        __dirname,
-        "node_modules",
-        "@shopware-pwa",
-        "default-theme",
-        "cms",
-        "SomeComponent.vue"
-      )
+      path.join("mocked-theme", "cms", "SomeComponent.vue")
     );
   });
 });

--- a/packages/nuxt-module/__tests__/extendLocales.spec.ts
+++ b/packages/nuxt-module/__tests__/extendLocales.spec.ts
@@ -25,6 +25,7 @@ describe("nuxt-module - extendLocales", () => {
   const mockedConfig: ShopwarePwaConfigFile = {
     shopwareEndpoint: "mockedEndpoint",
     shopwareAccessToken: "mockedToken",
+    theme: "some-theme",
   };
 
   beforeEach(() => {

--- a/packages/nuxt-module/__tests__/module.spec.ts
+++ b/packages/nuxt-module/__tests__/module.spec.ts
@@ -21,6 +21,7 @@ const mockedUtils = utils as jest.Mocked<typeof utils>;
 const mockedTheme = theme as jest.Mocked<typeof theme>;
 const mockedFiles = files as jest.Mocked<typeof files>;
 const consoleErrorSpy = jest.spyOn(console, "error");
+const consoleInfoSpy = jest.spyOn(console, "info");
 const mockedChokidar = chokidar as jest.Mocked<typeof chokidar>;
 const mockedFse = fse as jest.Mocked<typeof fse>;
 
@@ -41,7 +42,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     nuxt: { hook: jest.fn() },
     extendBuild: (method: Function): number => methods.push(method),
   };
-  let THEME_SOURCE = path.join("node_modules", "theme");
+  let THEME_SOURCE = path.join("node_modules", "theme-name");
   let PROJECT_SOURCE = "src";
   let TARGET_SOURCE = path.join(".shopware-pwa", "source");
   /**
@@ -57,6 +58,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     mockedUtils.loadConfig.mockResolvedValue({
       shopwareEndpoint: "mockedEndpoint",
       shopwareAccessToken: "mockedToken",
+      theme: "theme-name",
     });
     webpackConfig = {
       resolve: {
@@ -79,6 +81,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     };
 
     consoleErrorSpy.mockImplementationOnce(() => {});
+    consoleInfoSpy.mockImplementationOnce(() => {});
     mockedTheme.getThemeSourcePath.mockReturnValue(THEME_SOURCE);
     mockedTheme.getTargetSourcePath.mockReturnValue(TARGET_SOURCE);
     mockedTheme.getProjectSourcePath.mockReturnValue(PROJECT_SOURCE);
@@ -163,10 +166,19 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     );
   });
 
+  it("should show info which theme is used from config", async () => {
+    mockedUtils.loadConfig.mockResolvedValueOnce({
+      theme: "my-theme-name",
+    } as ShopwarePwaConfigFile);
+    await runModule(moduleObject, {});
+    expect(consoleInfoSpy).toBeCalledWith("Using theme: my-theme-name");
+  });
+
   it("should show console error when shopwareEndpoint contains api endpoint instead of just domain", async () => {
     mockedUtils.loadConfig.mockResolvedValueOnce({
       shopwareEndpoint: "mockedEndpoint/sales-channel-api/v1",
       shopwareAccessToken: "mockedToken",
+      theme: "mocked-theme",
     });
     await runModule(moduleObject, {});
     expect(consoleErrorSpy).toBeCalledWith(
@@ -232,7 +244,11 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
 
   it("should invoke extendCMS", async () => {
     await runModule(moduleObject, {});
-    expect(cms.extendCMS).toBeCalledWith(moduleObject);
+    expect(cms.extendCMS).toBeCalledWith(moduleObject, {
+      shopwareAccessToken: "mockedToken",
+      shopwareEndpoint: "mockedEndpoint",
+      theme: THEME_SOURCE,
+    });
   });
 
   it("should invoke extendLocales", async () => {
@@ -240,6 +256,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     expect(locales.extendLocales).toBeCalledWith(moduleObject, {
       shopwareAccessToken: "mockedToken",
       shopwareEndpoint: "mockedEndpoint",
+      theme: THEME_SOURCE,
     });
   });
 
@@ -298,7 +315,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     const onMock = jest
       .fn()
       .mockImplementation((name, fn) => invocationList.push(fn));
-    mockedChokidar.watch.mockReturnValueOnce({ on: onMock });
+    mockedChokidar.watch.mockReturnValueOnce({ on: onMock } as any);
     await runModule(moduleObject, {});
     expect(onMock).toBeCalledWith("all", expect.any(Function));
     expect(invocationList.length).toEqual(1);
@@ -320,10 +337,10 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     // first invocation is for onThemeFilesChanged
     mockedChokidar.watch.mockReturnValueOnce({
       on: () => {},
-    });
+    } as any);
     mockedChokidar.watch.mockReturnValueOnce({
       on: onMock,
-    });
+    } as any);
     await runModule(moduleObject, {});
     expect(onMock).toBeCalledWith("all", expect.any(Function));
     expect(invocationList.length).toEqual(1);

--- a/packages/nuxt-module/__tests__/module.spec.ts
+++ b/packages/nuxt-module/__tests__/module.spec.ts
@@ -41,7 +41,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     nuxt: { hook: jest.fn() },
     extendBuild: (method: Function): number => methods.push(method),
   };
-  let BASE_SOURCE = path.join("node_modules", "theme");
+  let THEME_SOURCE = path.join("node_modules", "theme");
   let PROJECT_SOURCE = "src";
   let TARGET_SOURCE = path.join(".shopware-pwa", "source");
   /**
@@ -79,7 +79,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     };
 
     consoleErrorSpy.mockImplementationOnce(() => {});
-    mockedTheme.getBaseSourcePath.mockReturnValue(BASE_SOURCE);
+    mockedTheme.getThemeSourcePath.mockReturnValue(THEME_SOURCE);
     mockedTheme.getTargetSourcePath.mockReturnValue(TARGET_SOURCE);
     mockedTheme.getProjectSourcePath.mockReturnValue(PROJECT_SOURCE);
     mockedChokidar.watch.mockReturnValue({ on: () => {} });
@@ -94,7 +94,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
   it("should invoke useThemeAndProjectFiles", async () => {
     await runModule(moduleObject, {});
     expect(mockedTheme.useThemeAndProjectFiles).toBeCalledWith({
-      BASE_SOURCE,
+      THEME_SOURCE,
       PROJECT_SOURCE,
       TARGET_SOURCE,
     });
@@ -282,10 +282,10 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
   it("should start watching files on development mode", async () => {
     moduleObject.options.dev = true;
     await runModule(moduleObject, {});
-    expect(mockedChokidar.watch).toBeCalledWith([BASE_SOURCE], {
+    expect(mockedChokidar.watch).toBeCalledWith([THEME_SOURCE], {
       followSymlinks: true,
       ignoreInitial: true,
-      ignored: path.join(BASE_SOURCE, "node_modules/**/*"),
+      ignored: path.join(THEME_SOURCE, "node_modules/**/*"),
     });
     expect(mockedChokidar.watch).toBeCalledWith(["src"], {
       ignoreInitial: true,
@@ -304,7 +304,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     expect(invocationList.length).toEqual(1);
     invocationList[0]("add", "some/filepath.vue");
     expect(mockedTheme.onThemeFilesChanged).toBeCalledWith({
-      BASE_SOURCE,
+      THEME_SOURCE,
       PROJECT_SOURCE,
       TARGET_SOURCE,
       event: "add",
@@ -329,7 +329,7 @@ describe("nuxt-module - ShopwarePWAModule runModule", () => {
     expect(invocationList.length).toEqual(1);
     invocationList[0]("add", "some/project/filepath.vue");
     expect(mockedTheme.onProjectFilesChanged).toBeCalledWith({
-      BASE_SOURCE,
+      THEME_SOURCE,
       PROJECT_SOURCE,
       TARGET_SOURCE,
       event: "add",

--- a/packages/nuxt-module/__tests__/useThemeAndProjectFiles.spec.ts
+++ b/packages/nuxt-module/__tests__/useThemeAndProjectFiles.spec.ts
@@ -2,7 +2,7 @@ import {
   useThemeAndProjectFiles,
   filterNodeModules,
   getTargetSourcePath,
-  getBaseSourcePath,
+  getThemeSourcePath,
   getProjectSourcePath,
   onThemeFilesChanged,
   onProjectFilesChanged,
@@ -14,7 +14,7 @@ jest.mock("fs-extra");
 const mockedFse = fse as jest.Mocked<typeof fse>;
 
 describe("nuxt-module - theme", () => {
-  let TARGET_SOURCE: string, BASE_SOURCE: string, PROJECT_SOURCE: string;
+  let TARGET_SOURCE: string, THEME_SOURCE: string, PROJECT_SOURCE: string;
 
   const moduleObject: any = {
     options: {
@@ -38,7 +38,7 @@ describe("nuxt-module - theme", () => {
       ".shopware-pwa",
       "source"
     );
-    BASE_SOURCE = path.join(
+    THEME_SOURCE = path.join(
       moduleObject.options.rootDir,
       "node_modules",
       "@shopware-pwa",
@@ -53,7 +53,7 @@ describe("nuxt-module - theme", () => {
     it("should clean target dir before copying files", async () => {
       await useThemeAndProjectFiles({
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.emptyDir).toBeCalledWith(TARGET_SOURCE);
@@ -62,10 +62,10 @@ describe("nuxt-module - theme", () => {
     it("should copy base theme files to target directory", async () => {
       await useThemeAndProjectFiles({
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
-      expect(mockedFse.copy).toHaveBeenCalledWith(BASE_SOURCE, TARGET_SOURCE, {
+      expect(mockedFse.copy).toHaveBeenCalledWith(THEME_SOURCE, TARGET_SOURCE, {
         dereference: true,
         filter: filterNodeModules,
       });
@@ -74,7 +74,7 @@ describe("nuxt-module - theme", () => {
     it("should copy project files to target directory", async () => {
       await useThemeAndProjectFiles({
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).toHaveBeenLastCalledWith(
@@ -101,9 +101,9 @@ describe("nuxt-module - theme", () => {
       const path = getTargetSourcePath(moduleObject);
       expect(path).toEqual(TARGET_SOURCE);
     });
-    it("should get correct getBaseSourcePath", () => {
-      const path = getBaseSourcePath(moduleObject);
-      expect(path).toEqual(BASE_SOURCE);
+    it("should get correct getThemeSourcePath", () => {
+      const path = getThemeSourcePath(moduleObject);
+      expect(path).toEqual(THEME_SOURCE);
     });
     it("should get correct getProjectSourcePath", () => {
       const path = getProjectSourcePath(moduleObject);
@@ -116,9 +116,9 @@ describe("nuxt-module - theme", () => {
       mockedFse.pathExists.mockResolvedValueOnce(true as never);
       await onThemeFilesChanged({
         event: "add",
-        filePath: path.join(BASE_SOURCE, "testfile.vue"),
+        filePath: path.join(THEME_SOURCE, "testfile.vue"),
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).not.toBeCalled();
@@ -129,9 +129,9 @@ describe("nuxt-module - theme", () => {
       mockedFse.pathExists.mockResolvedValueOnce(true as never);
       await onThemeFilesChanged({
         event: "change",
-        filePath: path.join(BASE_SOURCE, "testfile.vue"),
+        filePath: path.join(THEME_SOURCE, "testfile.vue"),
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).not.toBeCalled();
@@ -142,9 +142,9 @@ describe("nuxt-module - theme", () => {
       mockedFse.pathExists.mockResolvedValueOnce(true as never);
       await onThemeFilesChanged({
         event: "unlink",
-        filePath: path.join(BASE_SOURCE, "testfile.vue"),
+        filePath: path.join(THEME_SOURCE, "testfile.vue"),
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).not.toBeCalled();
@@ -155,13 +155,13 @@ describe("nuxt-module - theme", () => {
       mockedFse.pathExists.mockResolvedValueOnce(false as never);
       await onThemeFilesChanged({
         event: "add",
-        filePath: path.join(BASE_SOURCE, "testfile.vue"),
+        filePath: path.join(THEME_SOURCE, "testfile.vue"),
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).toBeCalledWith(
-        path.join(BASE_SOURCE, "testfile.vue"),
+        path.join(THEME_SOURCE, "testfile.vue"),
         path.join(TARGET_SOURCE, "testfile.vue")
       );
       expect(mockedFse.remove).not.toBeCalled();
@@ -171,13 +171,13 @@ describe("nuxt-module - theme", () => {
       mockedFse.pathExists.mockResolvedValueOnce(false as never);
       await onThemeFilesChanged({
         event: "change",
-        filePath: path.join(BASE_SOURCE, "components", "testfile.vue"),
+        filePath: path.join(THEME_SOURCE, "components", "testfile.vue"),
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).toBeCalledWith(
-        path.join(BASE_SOURCE, "components", "testfile.vue"),
+        path.join(THEME_SOURCE, "components", "testfile.vue"),
         path.join(TARGET_SOURCE, "components", "testfile.vue")
       );
       expect(mockedFse.remove).not.toBeCalled();
@@ -187,9 +187,9 @@ describe("nuxt-module - theme", () => {
       mockedFse.pathExists.mockResolvedValueOnce(false as never);
       await onThemeFilesChanged({
         event: "unlink",
-        filePath: path.join(BASE_SOURCE, "testfile.vue"),
+        filePath: path.join(THEME_SOURCE, "testfile.vue"),
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).not.toBeCalled();
@@ -205,7 +205,7 @@ describe("nuxt-module - theme", () => {
         event: "add",
         filePath: path.join(PROJECT_SOURCE, "testfile.vue"),
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).toBeCalledWith(
@@ -219,7 +219,7 @@ describe("nuxt-module - theme", () => {
         event: "change",
         filePath: path.join(PROJECT_SOURCE, "testfile.vue"),
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).toBeCalledWith(
@@ -234,11 +234,11 @@ describe("nuxt-module - theme", () => {
         event: "unlink",
         filePath: path.join(PROJECT_SOURCE, "testfile.vue"),
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).toBeCalledWith(
-        path.join(BASE_SOURCE, "testfile.vue"),
+        path.join(THEME_SOURCE, "testfile.vue"),
         path.join(TARGET_SOURCE, "testfile.vue")
       );
       expect(mockedFse.remove).not.toBeCalled();
@@ -249,7 +249,7 @@ describe("nuxt-module - theme", () => {
         event: "unlink",
         filePath: path.join(PROJECT_SOURCE, "testfile.vue"),
         TARGET_SOURCE,
-        BASE_SOURCE,
+        THEME_SOURCE,
         PROJECT_SOURCE,
       });
       expect(mockedFse.copy).not.toBeCalled();

--- a/packages/nuxt-module/__tests__/utils.spec.ts
+++ b/packages/nuxt-module/__tests__/utils.spec.ts
@@ -56,16 +56,21 @@ describe("nuxt-module - utils", () => {
       expect(result).toEqual({
         shopwareAccessToken: "qweqwe",
         shopwareEndpoint: "https://instance.com",
+        theme: "@shopware-pwa/default-theme",
       });
     });
 
-    it("should return empty object when no config found", async () => {
+    it("should return default config object when no config found", async () => {
       mockedCosmiconfigPackage.cosmiconfig.mockReturnValueOnce({
         search: () => null,
       } as never);
       moduleObject.options.rootDir = `${__dirname}/files_tests`;
       const result = await loadConfig(moduleObject);
-      expect(result).toEqual({});
+      expect(result).toEqual({
+        shopwareAccessToken: "SWSC40-LJTNO6COUEN7CJMXKLA",
+        shopwareEndpoint: "https://pwa-demo-api.shopware.com",
+        theme: "@shopware-pwa/default-theme",
+      });
     });
   });
 });

--- a/packages/nuxt-module/src/cms.ts
+++ b/packages/nuxt-module/src/cms.ts
@@ -1,8 +1,15 @@
 import path from "path";
-import { NuxtModuleOptions, WebpackConfig } from "./interfaces";
+import {
+  NuxtModuleOptions,
+  ShopwarePwaConfigFile,
+  WebpackConfig,
+} from "./interfaces";
 import jetpack from "fs-jetpack";
 
-export function extendCMS(moduleObject: NuxtModuleOptions) {
+export function extendCMS(
+  moduleObject: NuxtModuleOptions,
+  shopwarePwaConfig: ShopwarePwaConfigFile
+) {
   // Throw error with instruction if CMS module is not prepared
   const cmsModuleExists = jetpack.exists(
     path.join(
@@ -20,15 +27,7 @@ export function extendCMS(moduleObject: NuxtModuleOptions) {
 
   // Get main cms vue files to create aliases for them
   const allThemeCmsFiles =
-    jetpack.list(
-      path.join(
-        moduleObject.options.rootDir,
-        "node_modules",
-        "@shopware-pwa",
-        "default-theme",
-        "cms"
-      )
-    ) || [];
+    jetpack.list(path.join(shopwarePwaConfig.theme, "cms")) || [];
   const cmsCatalogFiles = allThemeCmsFiles.filter((name) =>
     name.includes(".vue")
   );
@@ -43,10 +42,7 @@ export function extendCMS(moduleObject: NuxtModuleOptions) {
 
     cmsCatalogFiles.forEach((cmsFile) => {
       config.resolve.alias["sw-cms/" + cmsFile.replace(".vue", "")] = path.join(
-        moduleObject.options.rootDir,
-        "node_modules",
-        "@shopware-pwa",
-        "default-theme",
+        shopwarePwaConfig.theme,
         "cms",
         cmsFile
       );

--- a/packages/nuxt-module/src/interfaces.ts
+++ b/packages/nuxt-module/src/interfaces.ts
@@ -43,6 +43,7 @@ export interface WebpackContext {
 export interface ShopwarePwaConfigFile {
   shopwareEndpoint: string;
   shopwareAccessToken: string;
+  theme: string;
   defaultLanguageCode?: string;
   apiDefaults?: {
     [composableName: string]: {

--- a/packages/nuxt-module/src/utils.ts
+++ b/packages/nuxt-module/src/utils.ts
@@ -11,10 +11,23 @@ export function invokeRebuild(moduleObject: NuxtModuleOptions) {
   );
 }
 
+// TODO move to commons with shopware-pwa-extension.ts
+const defaultConfig = {
+  shopwareEndpoint: "https://pwa-demo-api.shopware.com",
+  shopwareAccessToken: "SWSC40-LJTNO6COUEN7CJMXKLA",
+  theme: "@shopware-pwa/default-theme",
+};
+
 export async function loadConfig(
   moduleObject: NuxtModuleOptions
 ): Promise<ShopwarePwaConfigFile> {
   const explorer = cosmiconfig("shopware-pwa");
   const result = await explorer.search();
-  return result?.config || {};
+  const loadedConfig = result?.config || {};
+  return {
+    // load default config
+    ...defaultConfig,
+    // overwrite by user config
+    ...loadedConfig,
+  };
 }


### PR DESCRIPTION
## Changes

<!-- Describe the changes which you did and which issue you're closing
 example: closes #230
-->
related: #1158 

The feature allows using another theme as a base, by simply putting its name into `shopware-pwa.config.js` file like this:
```js
module.exports = {
  shopwareEndpoint: 'https://pwa-demo-api.shopware.com',
  shopwareAccessToken: 'SWSC40-LJTNO6COUEN7CJMXKLA',
  // theme: '@shopware-pwa/default-theme',
  theme: 'my-theme',
}
```

1. It looks by path, so rootDirectory/path
2. If not found it looks in node modules

Preferably theme should be placed in node_modules so published as NPM package.

Next things to do with the task is to add tools for theme building.

<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
