### PR TITLE
0.5 has been released meanwhile

### DIFF
--- a/docs/landing/getting-started/upgrade.md
+++ b/docs/landing/getting-started/upgrade.md
@@ -12,7 +12,7 @@ The supported API versions of Shopware 6 are v3 and v2. Generally speaking, each
 
 We want Shopware PWA to be in sync with the latest endpoints of Shopware, to be able to ship new features to you as soon as they are released within Shopware.
 
-## Migrate version 0.4.x to 0.5.x - not released yet!
+## Migrate version 0.4.x to 0.5.x
 
 **MIGRATION STEPS**:
 


### PR DESCRIPTION
## Changes

Remove _not released yet_ notice from the migration guide for 0.5

### Checklist

- [x] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [x] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
