### PR TITLE
fix(helpers): prevent double slashes in routes

### DIFF
--- a/packages/helpers/__tests__/category/getCategoryUrl.spec.ts
+++ b/packages/helpers/__tests__/category/getCategoryUrl.spec.ts
@@ -20,4 +20,8 @@ describe("Shopware helpers - getCategoryUrl", () => {
     const result = getCategoryUrl({ route: { path: "some/path" } });
     expect(result).toEqual("/some/path");
   });
+  it("should return category path with one slash before, even if it's set already", () => {
+    const result = getCategoryUrl({ route: { path: "/some/path" } });
+    expect(result).toEqual("/some/path");
+  });
 });

--- a/packages/helpers/src/category/getCategoryUrl.ts
+++ b/packages/helpers/src/category/getCategoryUrl.ts
@@ -6,4 +6,5 @@ import { Category } from "@shopware-pwa/commons/interfaces/models/content/catego
  * @alpha
  */
 export const getCategoryUrl = (category: Partial<Category>): string =>
+  (category?.route?.path?.charAt(0) === "/" && category.route.path) ||
   `/${category?.route?.path || ""}`;


### PR DESCRIPTION
## Changes

prevent passing the "//" routes to the router-link for category urls. 
nuxt router couldn't parse it as valid URL in `%test-project-dir%/,nuxt/router.js` so it throws an exception during normialization process
![image](https://user-images.githubusercontent.com/5596960/101484831-866c0c80-395a-11eb-8ff8-0345f7da4e2e.png)


<!-- Paste here screenshot if there are visual changes -->

### Checklist

- [ ] the [list of features](docs/guide/FEATURELIST.md) is updated (if it's a feature and it's relevant)
- [ ] I followed [contributing](https://github.com/DivanteLtd/shopware-pwa/blob/master/CONTRIBUTING.md) guidelines
